### PR TITLE
added hash and sign methods to feeds

### DIFF
--- a/lib/feed.js
+++ b/lib/feed.js
@@ -98,6 +98,14 @@ function Feed (core, opts) {
 
 inherits(Feed, events.EventEmitter)
 
+Feed.prototype.hash = function () {
+  return this._merkle && this._merkle.roots.length ? hash.tree(this._merkle.roots) : null
+}
+
+Feed.prototype.sign = function (message) {
+  return this.secretKey ? signatures.sign(message, this.secretKey) : null
+}
+
 Feed.prototype.replicate =
 Feed.prototype.createReplicationStream = function () {
   return this.swarm.replicate({id: this._core.id})
@@ -315,7 +323,7 @@ Feed.prototype.finalize = function (cb) {
 
   function onflush (err) {
     if (err) return cb(err)
-    self.key = self._merkle.roots.length ? hash.tree(self._merkle.roots) : null
+    self.key = self.hash()
     self.publicId = self.key && hash.publicId(self.key)
     if (!self.key) return cb()
     self._sync(null, onsync)
@@ -472,7 +480,7 @@ Feed.prototype._append = function (buffers, cb) {
         })
 
         if (this.live) {
-          var sig = signatures.sign(hash.tree(this._merkle.roots), this.secretKey)
+          var sig = this.sign(this.hash())
           batch.push({
             type: 'put',
             key: '!signatures!' + this._prefix + (node.index + 2),


### PR DESCRIPTION
feed.hash() returns the hash of the merkle roots or null if there are no roots
feed.sign(message) returns the signed message or null if there is no secret key