### PR TITLE
failing test for a write stream into a read stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "varint": "^4.0.0"
   },
   "devDependencies": {
+    "concat-stream": "^1.5.1",
     "memdb": "^1.3.1",
     "random-access-memory": "^1.0.0",
     "standard": "^6.0.8",

--- a/test/stream.js
+++ b/test/stream.js
@@ -1,0 +1,29 @@
+var tape = require('tape')
+var memdb = require('memdb')
+var ram = require('random-access-memory')
+var concat = require('concat-stream')
+var hypercore = require('../')
+
+tape('createWriteStream to createReadStream', function (t) {
+  t.plan(1)
+  var core1 = create()
+  var core2 = create()
+
+  var w = core1.createWriteStream()
+  w.end('hello')
+
+  var r = core2.createReadStream(w.publicId)
+  r.pipe(concat(function (body) {
+    t.deepEqual(body.toString(), 'hello')
+  }))
+  replicate(w.feed, r.feed)
+})
+
+function replicate (a, b) {
+  var stream = a.replicate()
+  stream.pipe(b.replicate()).pipe(stream)
+}
+
+function create () {
+  return hypercore(memdb())
+}


### PR DESCRIPTION
This failing test reproduces the `Error: Channel is not open yet` error from https://github.com/mafintosh/hypercore/issues/15