### PR TITLE
fix default key encoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var crypto = require('crypto')
+var defaults = require('levelup-defaults')
 var subleveldown = require('subleveldown')
 var bulk = require('bulk-write-stream')
 var collect = require('stream-collector')
@@ -16,7 +17,7 @@ function Hypercore (db, opts) {
 
   this.id = opts.id || crypto.randomBytes(32)
 
-  this._db = db // TODO: needs levelup-defaults to force binary?
+  this._db = defaults(db, {keyEncoding: 'utf8'})
   this._nodes = subleveldown(db, 'nodes', {valueEncoding: messages.Node})
   this._data = subleveldown(db, 'data', {valueEncoding: 'binary'})
   this._signatures = subleveldown(db, 'signatures', {valueEncoding: 'binary'})

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "hypercore-protocol": "^4.2.0",
     "inherits": "^2.0.1",
     "last-one-wins": "^1.0.4",
+    "levelup-defaults": "^1.0.2",
     "merkle-tree-stream": "^3.0.3",
     "protocol-buffers": "^3.1.6",
     "sodium-signatures": "^1.2.2",

--- a/test/helpers/create.js
+++ b/test/helpers/create.js
@@ -2,5 +2,6 @@ var hypercore = require('../../')
 var memdb = require('memdb')
 
 module.exports = function create () {
+  // ensure hypercore overwrites the db's default encoding
   return hypercore(memdb({keyEncoding: 'json'}))
 }

--- a/test/helpers/create.js
+++ b/test/helpers/create.js
@@ -2,5 +2,5 @@ var hypercore = require('../../')
 var memdb = require('memdb')
 
 module.exports = function create () {
-  return hypercore(memdb())
+  return hypercore(memdb({keyEncoding: 'json'}))
 }


### PR DESCRIPTION
The db i passed to hyperdrive/hypercore had `{keyEncoding: bytewise}`, so this was causing bugs.

The comment I removed said "binary" encoding, but I the keys written were all strings so I used `utf8` for simplicity.