### PR TITLE
add options.values to list() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,15 @@ See the [Storage API](#storage-api) section for more info
 
 Create a generic replication stream. Use the `feed.replicate(stream)` API described below to replicate specific feeds of data.
 
-#### `var stream = core.list([callback])`
+#### `var stream = core.list([options], [callback])`
 
-List all feed keys in the database. Optionally you can pass a callback to buffer them into an array.
+List all feed keys in the database. Optionally you can pass a callback to buffer them into an array. Options include:
+
+``` js
+{
+  values: false // set this to get feed attributes, not just feed keys
+}
+```
 
 ## `Feed API`
 

--- a/index.js
+++ b/index.js
@@ -67,12 +67,20 @@ Hypercore.prototype.stat = function (key, cb) {
   })
 }
 
-Hypercore.prototype.list = function (cb) {
+Hypercore.prototype.list = function (opts, cb) {
+  if (typeof opts === 'function') {
+    cb = opts
+    opts = null
+  }
   var stream = this._feeds.createValueStream({
     valueEncoding: {
       asBuffer: true,
       decode: function (key) {
-        return messages.Feed.decode(key).key
+        var value = messages.Feed.decode(key)
+        if (opts && opts.values) {
+          return value
+        }
+        return value.key
       }
     }
   })

--- a/test/toplevel.js
+++ b/test/toplevel.js
@@ -1,0 +1,60 @@
+var tape = require('tape')
+var hypercore = require('./helpers/create')
+
+tape('list keys', function (t) {
+  var hc = hypercore()
+  var feeds = [hc.createFeed(), hc.createFeed(), hc.createFeed()]
+
+  finalizeAll(feeds, function () {
+    hc.list(function (err, keys) {
+      if (err) throw err
+
+      feeds.sort(sortByKey)
+      keys.sort(sortByKey)
+
+      t.deepEqual(keys, feeds.map(function (f) { return f.key }))
+      t.end()
+    })
+  })
+})
+
+tape('list values', function (t) {
+  var hc = hypercore()
+  var feeds = [hc.createFeed(), hc.createFeed(), hc.createFeed()]
+
+  finalizeAll(feeds, function () {
+    hc.list({ values: true }, function (err, values) {
+      if (err) throw err
+
+      feeds.sort(sortByKey)
+      values.sort(sortByKey)
+
+      t.deepEqual(values, feeds.map(function (f) {
+        return {
+          discoveryKey: f.discoveryKey,
+          key: f.key,
+          live: f.live,
+          prefix: f.prefix,
+          secretKey: f.secretKey
+        }
+      }))
+      t.end()
+    })
+  })
+})
+
+function finalizeAll (feeds, cb) {
+  feeds.forEach(function (f) { f.finalize(done) })
+  var numDone = 0
+  function done () {
+    if (++numDone === feeds.length) {
+      cb()
+    }
+  }
+}
+
+function sortByKey (a, b) {
+  var aKey = Buffer.isBuffer(a) ? a : a.key
+  var bKey = Buffer.isBuffer(b) ? b : b.key
+  return aKey.compare(bKey)
+}


### PR DESCRIPTION
This PR adds the `hypercore.list({values: true})` usecase, which enables an API consumer to quickly read listing metadata.

In my case, I needed to list all the archives that I own. This PR lets me quickly fetch all archives along with their secret keys. If the secret key is populated, I know I'm the owner.