### PR TITLE
Add failing download events to download-finished test

### DIFF
--- a/test/replicate.js
+++ b/test/replicate.js
@@ -203,11 +203,17 @@ tape('emits download finished', function (t) {
   feed.append('world')
   feed.flush(function () {
     var clone = core2.createFeed(feed.key)
+    var downloadCount = 0
+    clone.on('download', function () {
+      downloadCount++
+    })
 
     clone.once('download-finished', function () {
       t.pass('download finished')
+      t.same(downloadCount, 2, 'Two download events emitted')
       clone.on('download-finished', function () {
         t.pass('download finished again')
+        t.same(downloadCount, 3, 'Three download events emitted')
         t.end()
       })
       feed.append('update')


### PR DESCRIPTION
`feed.on('download-finished')` fires before all of the `feed.on('download')` events. 

This PR has a failing test checking if all the `feed.on('download')` events fire before the `feed.on('download-finished')`.

If you have some pointers on how to solve it, I'd be happy try. Couldn't quite figure it out yet.
