### PR TITLE
Emit block index with feed 'update' event

### DIFF
--- a/lib/feed.js
+++ b/lib/feed.js
@@ -82,7 +82,7 @@ function Feed (core, opts) {
       self.bitfield.set(blk, true)
       self._appending--
       self._drain(blk)
-      self.emit('update')
+      self.emit('update', blk)
     }
 
     self.bytes += self._appendingBytes
@@ -453,10 +453,11 @@ Feed.prototype._putRoots = function (top, batch, nodes, nodesOffset, sig, cb) {
 
     if (indexes.length) {
       var newBlocks = flat.rightSpan(indexes[indexes.length - 1]) / 2 + 1
-      if (newBlocks > self.blocks) {
+      var oldBlocks = self.blocks
+      if (newBlocks > oldBlocks) {
         self.blocks = newBlocks
         self.bytes = byteSize(roots)
-        self.emit('update')
+        while(oldBlocks++ < newBlocks) self.emit('update', oldBlocks)
       }
     }
 

--- a/lib/feed.js
+++ b/lib/feed.js
@@ -457,7 +457,7 @@ Feed.prototype._putRoots = function (top, batch, nodes, nodesOffset, sig, cb) {
       if (newBlocks > oldBlocks) {
         self.blocks = newBlocks
         self.bytes = byteSize(roots)
-        while(oldBlocks++ < newBlocks) self.emit('update', oldBlocks)
+        while (oldBlocks++ < newBlocks) self.emit('update', oldBlocks)
       }
     }
 


### PR DESCRIPTION
This event is not documented, but I assume from the context that it will emit whenever the feed is changed, ie. data is appended. I intend of using this in [`hypercore-sparse-index`](https://github.com/emilbayes/hypercore-sparse-index) to keep the index up to date whenever data is added to the feed.

If this is not going to be part of the public API, or if I misunderstood its purpose, just close :smile: