### PR TITLE
wip: non live replication

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -45,6 +45,7 @@ function Peer (feed) {
   this._tick = 0
   this._index = -1
   this._blocks = 0
+  this._once = true
 
   this.uploading = true
   this.downloading = true
@@ -53,12 +54,14 @@ function Peer (feed) {
   this.channel = null
   this.stream = null
 
+  this.remoteEnded = false
   this.remotePausing = false
   this.remoteBitfield = bitfield(16)
   this.remoteTree = tree(16)
   this.remoteRequests = []
   this.reading = false
 
+  this.ended = false
   this.pausing = false
   this.responses = []
   this.requests = []
@@ -75,6 +78,11 @@ Peer.prototype.have = function (block) {
 // expose the update methods for easier debugging
 
 Peer.prototype.update = function () {
+  if (this.ended && this.remoteEnded) {
+    this.channel.close()
+    return
+  }
+
   if (!this.downloading || this.remotePausing) return
   this.maxRequests = maxRequests(this.feed)
 
@@ -92,6 +100,30 @@ Peer.prototype.update = function () {
 Peer.prototype.updateAll = function () {
   for (var i = 0; i < this.feed.peers.length; i++) {
     this.feed.peers[i].update()
+  }
+}
+
+Peer.prototype.checkEnd = function () {
+  if (!this._once) return
+  this._once = false
+
+  var self = this
+  var downloaded = 0
+  var end = this._blocks
+
+  update()
+  this.feed.on('download', update)
+
+  function update () {
+    while (downloaded < end && self.feed.has(downloaded)) {
+      downloaded++
+    }
+    if (downloaded === end) {
+      self.feed.removeListener('download', update)
+      self.ended = true
+      self.channel.end()
+      self.update()
+    }
   }
 }
 
@@ -118,6 +150,7 @@ function ready (stream, feed, opts) {
   channel.on('cancel', oncancel)
   channel.on('pause', onpause)
   channel.on('resume', onresume)
+  channel.on('end', onend)
 
   // meta events
   channel.on('tick', ontick)
@@ -138,6 +171,11 @@ function onopen () {
       bitfield: rle.encode(peer.feed.bitfield.toBuffer())
     })
   }
+}
+
+function onend () {
+  this.state.remoteEnded = true
+  this.state.update()
 }
 
 function onwant (message) {
@@ -176,6 +214,7 @@ function onhave (message) {
 
   if (blocks > peer._blocks) peer._blocks = blocks
   peer.update() // TODO: if previous update failed we should only look in the update state
+  peer.checkEnd()
 }
 
 function onrequest (message) {
@@ -254,6 +293,11 @@ function onclose () {
   peer.feed.emit('peer-remove', peer)
   peer.updateAll()
   peer.emit('close')
+
+  process.nextTick(function () {
+    if (Object.keys(peer.stream.channels).length) return
+    peer.stream.finalize()
+  })
 }
 
 function remove (list, val) {
@@ -269,6 +313,7 @@ function write (self) {
   self.feed.put(next.block, next.value, next, function (err) {
     if (err) return destroy(self.channel, err)
 
+    self.checkEnd()
     self.feed.emit('download', next.block, next.value, self)
     self.responses.shift()
     if (self.responses.length) write(self)


### PR DESCRIPTION
per default replication streams will exit when the current snapshot has been synced between both peers (hyperlog style).

``` js
var hypercore = require('./')
var memdb = require('memdb')

var core1 = hypercore(memdb())
var core2 = hypercore(memdb())

var feed1 = core1.createFeed()
var feed2 = core2.createFeed(feed1.key)

feed1.append([
  'how',
  'are',
  'you',
  'doing?',
  'i',
  'am',
  'fine',
  'thanks',
  'what',
  'about',
  'you?'
])

feed1.flush(function () {
  var s1 = feed1.replicate()
  var s2 = feed2.replicate()

  s1.pipe(s2).pipe(s1)

  s1.on('end', function () {
    feed2.get(0, function (err, buf) {
      console.log('->', buf.toString())
    })
  })
})
```