### PR TITLE
Add unhave() to replication, and send unhave on failed reads.

### DIFF
--- a/lib/feed.js
+++ b/lib/feed.js
@@ -198,6 +198,7 @@ Feed.prototype.get = function (block, opts, cb) { // TODO: on static feeds retur
       if (!equals(blockHash, node.hash)) {
         self.bitfield.set(block, false) // remove from the local bitfield
         self._sync()
+
         var error = new Error('Block not found')
         error.notFound = true
         cb(error)

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -113,6 +113,12 @@ Peer.prototype.updateAll = function () {
   }
 }
 
+Peer.prototype.sendUnhaveToAll = function (msg) {
+  for (var i = 0; i < this.feed.peers.length; i++) {
+    this.feed.peers[i].channel.unhave(msg)
+  }
+}
+
 Peer.prototype.disconnect = function () {
   this.debug('disconnect()')
   this.channel.close()
@@ -234,7 +240,6 @@ function onunhave (message) {
     start++
   }
   peer.update()
-  console.log('ZZZZ')
 }
 
 function onrequest (message) {
@@ -421,7 +426,7 @@ function read (self) { // TODO: use a remote tree as well
       if (err) {
         if (err.notFound) {
           self.debug('read() verification failed, sending unhave')
-          self.channel.unhave({ start: next.block })
+          self.sendUnhaveToAll({ start: next.block })
           return loop()
         }
         self.debug('read() get failed, aborting', err)

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -142,6 +142,7 @@ function ready (stream, feed, opts) {
   feed.emit('peer-add', peer)
 
   channel.on('have', onhave)
+  channel.on('unhave', onunhave)
   channel.on('want', onwant)
   channel.on('request', onrequest)
   channel.on('data', ondata)
@@ -215,6 +216,25 @@ function onhave (message) {
 
   if (blocks > peer._blocks) peer._blocks = blocks
   peer.update() // TODO: if previous update failed we should only look in the update state
+}
+
+function onunhave (message) {
+  var peer = this.state
+
+  var start = message.start
+  var end = message.end || (start + 1)
+  peer.debug('onunhave() start=%d end=%d', start, end)
+
+  while (start < end) {
+    peer.remoteBitfield.set(start, false)
+    if (remove(peer.requests, message.block) === 0) {
+      peer.debug('tick reset (received top-of-queue request)')
+      peer._tick = 0
+    }
+    start++
+  }
+  peer.update()
+  console.log('ZZZZ')
 }
 
 function onrequest (message) {
@@ -397,8 +417,13 @@ function read (self) { // TODO: use a remote tree as well
       return destroy(self.channel, err)
     }
 
-    self.feed.get(next.block, { verify: self.verifyReplicationReads }, function (err, data) {
+    self.feed.get(next.block, { verify: self.feed.verifyReplicationReads }, function (err, data) {
       if (err) {
+        if (err.notFound) {
+          self.debug('read() verification failed, sending unhave')
+          self.channel.unhave({ start: next.block })
+          return loop()
+        }
         self.debug('read() get failed, aborting', err)
         return destroy(self.channel, err)
       }
@@ -416,9 +441,13 @@ function read (self) { // TODO: use a remote tree as well
         signature: proof.signature
       })
 
-      self.remoteRequests.shift()
-      self.reading = false
-      if (self.remoteRequests.length) read(self)
+      loop()
     })
   })
+
+  function loop () {
+    self.remoteRequests.shift()
+    self.reading = false
+    if (self.remoteRequests.length) read(self)
+  }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "debug": "^2.5.2",
     "flat-tree": "^1.4.0",
     "from2": "^2.1.1",
-    "hypercore-protocol": "^5.0.0",
+    "hypercore-protocol": "^5.1.0",
     "inherits": "^2.0.1",
     "last-one-wins": "^1.0.4",
     "levelup-defaults": "^2.0.0",

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -371,23 +371,21 @@ tape('verify replication reads', function (t) {
 
   feed.finalize(function () {
     // modify in storage
-    feed.storage.put(4, Buffer('--'))
+    feed.storage.put(2, Buffer('--'))
 
     var clone = core2.createFeed(feed.key, {storage: ram()})
 
-    var streams = replicate(clone, feed)
+    replicate(clone, feed)
 
-    streams.stream1.on('error', function () {
-      // ignore
-    })
-    streams.stream1.on('close', function () {
-      // TODO: when unhave() is implemented, these 4 blocks will have synced:
-      // t.equal(clone.has(0), true, 'has block 0')
-      // t.equal(clone.has(1), true, 'has block 1')
-      // t.equal(clone.has(2), true, 'has block 2')
-      // t.equal(clone.has(3), true, 'has block 3')
-
-      t.equal(clone.has(4), false, 'doesnt have block 4')
+    var missing = 4
+    clone.on('download', function (block) {
+      console.log('download', block)
+      if (--missing > 0) return
+      t.equal(clone.has(0), true, 'has block 0')
+      t.equal(clone.has(1), true, 'has block 1')
+      t.equal(clone.has(2), false, 'doesnt have block 2')
+      t.equal(clone.has(3), true, 'has block 3')
+      t.equal(clone.has(4), true, 'has block 4')
       t.end()
     })
   })


### PR DESCRIPTION
This PR improves `verifyReplicationReads` behavior by sending an unhave() and resuming the connection, rather than destroying the connection with an error.