### PR TITLE
Fix: Pass get options through _openAndGet

### DIFF
--- a/lib/feed.js
+++ b/lib/feed.js
@@ -176,7 +176,7 @@ Feed.prototype.get = function (block, opts, cb) { // TODO: on static feeds retur
   if (!opts) opts = {}
   var self = this
 
-  if (!this.opened) return this._openAndGet(block, cb)
+  if (!this.opened) return this._openAndGet(block, opts, cb)
 
   if (!this.bitfield.get(block)) {
     if (opts.wait === false) {
@@ -820,11 +820,11 @@ Feed.prototype._openAndPut = function (block, data, proof, cb) {
   })
 }
 
-Feed.prototype._openAndGet = function (block, cb) {
+Feed.prototype._openAndGet = function (block, opts, cb) {
   var self = this
   this.open(function (err) {
     if (err) return cb(err)
-    self.get(block, cb)
+    self.get(block, opts, cb)
   })
 }
 


### PR DESCRIPTION
This fixes an edgecase where, if the feed was not open yet, the opts would not get correctly passed to the get() after open