### PR TITLE
Fix: dont make new requests when the channel is closed.

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -81,7 +81,7 @@ Peer.prototype.have = function (block) {
 // expose the update methods for easier debugging
 
 Peer.prototype.update = function () {
-  if (!this.downloading || this.remotePausing) return
+  if (!this.downloading || this.remotePausing || this.channel.closed) return
   this.maxRequests = maxRequests(this.feed)
   this.maxResponses = this.maxRequests * 2
 


### PR DESCRIPTION
New requests were being made after the channel closed. These requests would mark the selection _reserved bits, but never release them, causing replication to fail due to a set of stalled-out blocks.