### PR TITLE
add 'complete' event for download finished

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -319,6 +319,11 @@ Peer.prototype._downloadRange = function (range) {
     if (!range.bytes && ite.seek(0).next() === -1 && (range.end > -1 && this.remoteLength >= range.end)) {
       set.remove(this.feed._selections, range)
       range.callback(null)
+      var block = 0
+      while (this.feed.has(block)) block++
+      if (block === this.feed.length) {
+        this.feed.emit('complete')
+      }
       if (!this.live && !this.sparse && !this.feed._selections.length) this.end()
     }
     return


### PR DESCRIPTION
What if we add back the download-finished event but call it something else, like 'complete'? Any better ideas?