### PR TITLE
Add feed.has(start, [end])

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ If `start` is not specified it will default to 0.
 Return true if a data block is available locally.
 False otherwise.
 
+#### `var bool = feed.has(start, end)`
+Return true if all data blocks within a range are available locally.
+False otherwise.
+
 #### `feed.append(data, [callback])`
 
 Append a block of data to the feed.

--- a/index.js
+++ b/index.js
@@ -769,8 +769,10 @@ Feed.prototype.downloaded = function (start, end) {
   return this.bitfield.total(start, end)
 }
 
-Feed.prototype.has = function (index) {
-  return this.bitfield.get(index)
+Feed.prototype.has = function (start, end) {
+  if (end === undefined) return this.bitfield.get(start)
+  var total = end - start
+  return total === this.bitfield.total(start, end)
 }
 
 Feed.prototype.get = function (index, opts, cb) {

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -487,6 +487,31 @@ tape('get total downloaded chunks', function (t) {
   })
 })
 
+tape('feed has a range of chuncks', function (t) {
+  var feed = create()
+  feed.append(['a', 'b', 'c', 'e'])
+  feed.on('ready', function () {
+    var clone = create(feed.key, {sparse: true})
+    clone.get(0, function (err) {
+      t.error(err, 'no error')
+      clone.get(1, function (err) {
+        t.error(err, 'no error')
+        clone.get(2, function (err) {
+          t.error(err, 'no error')
+          t.ok(clone.has(1))
+          t.notOk(clone.has(3))
+          t.ok(clone.has(0, clone.length - 1))
+          t.notOk(clone.has(0, clone.length))
+          t.ok(clone.has(1, 3))
+          t.notOk(clone.has(3, 4))
+          t.end()
+        })
+      })
+    })
+    replicate(feed, clone, {live: true})
+  })
+})
+
 function same (t, val) {
   return function (err, data) {
     t.error(err, 'no error')


### PR DESCRIPTION
This is built on top of my last PR as it uses the bitfield.total function. As such the commit history has all the changes from that PR, but if https://github.com/mafintosh/hypercore/pull/101 is merged first I can rebase this one so the commit history is clean while including any other changes that might be needed on that PR.

I just wanted to open this up as I had time now. Let me know if there are any changes you would like made.