### PR TITLE
Add download opt to replicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Options include:
 ``` js
 {
   live: false, // keep replicating after all remote data has been downloaded?
+  download: true, // download data from peers?
   encrypt: true // encrypt the data sent using the hypercore key pair
 }
 ```

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -46,7 +46,7 @@ function Peer (feed, opts) {
   this.live = !!opts.live
 
   this.remoteDownloading = true
-  this.downloading = !feed.writable
+  this.downloading = !feed.writable && (opts.download !== false)
   this.uploading = true
 
   this.maxRequests = opts.maxRequests || feed.maxRequests || 16

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -551,7 +551,7 @@ tape('replicate no download', function (t) {
   feed.append(['a', 'b', 'c', 'd', 'e'], function () {
     var clone = create(feed.key)
 
-    clone.get(0, function (err) {
+    clone.get(0, function () {
       t.fail('Data was received')
     })
 

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -545,6 +545,26 @@ tape('feed has a large range', function (t) {
   })
 })
 
+tape('replicate no download', function (t) {
+  var feed = create()
+
+  feed.append(['a', 'b', 'c', 'd', 'e'], function () {
+    var clone = create(feed.key)
+
+    clone.get(0, function (err) {
+      t.fail('Data was received')
+    })
+
+    var stream = feed.replicate({live: true})
+    stream.pipe(clone.replicate({live: true, download: false})).pipe(stream)
+
+    setTimeout(() => {
+      t.pass('No data was received')
+      t.end()
+    }, 300)
+  })
+})
+
 function same (t, val) {
   return function (err, data) {
     t.error(err, 'no error')

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -558,7 +558,7 @@ tape('replicate no download', function (t) {
     var stream = feed.replicate({live: true})
     stream.pipe(clone.replicate({live: true, download: false})).pipe(stream)
 
-    setTimeout(() => {
+    setTimeout(function () {
       t.pass('No data was received')
       t.end()
     }, 300)


### PR DESCRIPTION
This makes it possible to enter the swarm while only uploading data, using the `download: false` on `replicate()`.

Adding an `upload` opt to replicate will take more work and I don't need that feature right now, so I'm just submitting this.