### PR TITLE
Manual bitfield memory management (WIP)

### DIFF
--- a/index.js
+++ b/index.js
@@ -934,6 +934,13 @@ Feed.prototype.close = function (cb) {
   this._ready(function () {
     self.writable = false
     self.readable = false
+    if (self.bitfield) {
+      self.bitfield.release()
+    }
+    if (self.tree) {
+      self.tree.release()
+    }
+    self._reserved.release()
     self._storage.close(cb)
   })
 }

--- a/lib/bitfield.js
+++ b/lib/bitfield.js
@@ -62,6 +62,10 @@ function Bitfield (buffer) {
   this._iterator = flat.iterator(0)
 }
 
+Bitfield.prototype.release = function () {
+  this.pages.release()
+}
+
 Bitfield.prototype.set = function (i, value) {
   var o = i & 7
   i = (i - o) / 8

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -355,6 +355,7 @@ Peer.prototype.destroy = function (err) {
   this._updateEnd()
   this._index = -1
   this.remoteWant = false
+  this.remoteBitfield.release()
   this.stream.destroy(err)
   this.feed._updatePeers()
   this.feed.emit('peer-remove', this)

--- a/lib/tree-index.js
+++ b/lib/tree-index.js
@@ -8,6 +8,10 @@ function TreeIndex (bits) {
   this.bitfield = bits || bitfield()
 }
 
+TreeIndex.prototype.release = function () {
+  this.bitfield.release()
+}
+
 TreeIndex.prototype.proof = function (index, opts) {
   if (!opts) opts = {}
 


### PR DESCRIPTION
I've been profiling Hashbase and Beaker lately. There are a few performance issues. One of the main causes I've found has been frequent GCs, both in Hashbase and Beaker. (In fact, this gets so bad that the GCs will eventually degrade both apps to the point that they need to restart.)

Here are a couple of screenshots showing the frequent GCs:

![screen shot 2017-10-16 at 4 36 25 pm](https://user-images.githubusercontent.com/1270099/31696606-2587b4fc-b378-11e7-8e2d-44643fb4adf7.png)
![screen shot 2017-10-16 at 5 56 23 pm](https://user-images.githubusercontent.com/1270099/31696607-259e6328-b378-11e7-8d93-941104dd521e.png)

I also think some of the allocations slow things down too. Here is the code that allocates pages taking a significant slice of time in Beaker:

![screen shot 2017-10-17 at 7 12 46 pm](https://user-images.githubusercontent.com/1270099/31696647-559c44a0-b378-11e7-9be6-03baa5b64cf4.png)

Unfortunately I cant get heap snapshots for Beaker yet (electron bug crashes when I try) but in Hashbase, during some heavy traffic, a 3 second period looked like this:

![screen shot 2017-10-17 at 8 27 46 pm](https://user-images.githubusercontent.com/1270099/31696878-c37be77c-b379-11e7-8cea-15e618db13fa.png)

Notice, 218 new Connection objects, and 249 deleted. So, a lot of connections stopping and starting. There's also a *ton* of arrays being allocated and destroyed. I'm 99% sure the pager's array allocations are the biggest slice of that, because it's creating a new 16kb array to support the `remoteBitfield` on every replication stream. The actual alloc size of each `pages` array is 131kb, and there are 374 pagers allocated in this period, which accounts for 48mb of the 50mb allocated. In terms of deallocations, 548 pagers * 131kb = 72mb of the 74mb deallocated. (Again, pretty sure I'm reading this stuff right, not 100% sure. I can share the snapshots if you like.)

Ok so there's pretty much two strategies to dealing with this. The first is, somehow we stop allocating the bitfields, or we come up with an even more sparse representation to work with. I can't say if that's possible and I doubt it. The second option is, we create our own memory pool for the pager so that we can stop the GC from running so much.

This PR starts the process of the second option by adding the memory `release()` calls. If we want to continue with this path, we'll need to implement `release()` in `sparse-bitfield` and `memory-pager`, and then implement the memory pool in `memory-pager`.