### PR TITLE
Detect mismatching keypair

### DIFF
--- a/index.js
+++ b/index.js
@@ -217,6 +217,12 @@ Feed.prototype._open = function (cb) {
     if (state.key) self.key = state.key
     if (state.secretKey) self.secretKey = state.secretKey
 
+    if (self.key && self.secretKey) {
+      var challenge = new Buffer('');
+      if (!crypto.verify(challenge, crypto.sign(challenge, self.secretKey), self.key))
+        return cb(new Error('Key and secret do not match'))
+    }
+
     if (!self.length) return onsignature(null, null)
     self._storage.getSignature(self.length - 1, onsignature)
 

--- a/index.js
+++ b/index.js
@@ -217,10 +217,12 @@ Feed.prototype._open = function (cb) {
     if (state.key) self.key = state.key
     if (state.secretKey) self.secretKey = state.secretKey
 
+    // verify key and secretKey go together
     if (self.key && self.secretKey) {
-      var challenge = new Buffer('');
-      if (!crypto.verify(challenge, crypto.sign(challenge, self.secretKey), self.key))
+      var challenge = new Buffer('')
+      if (!crypto.verify(challenge, crypto.sign(challenge, self.secretKey), self.key)) {
         return cb(new Error('Key and secret do not match'))
+      }
     }
 
     if (!self.length) return onsignature(null, null)


### PR DESCRIPTION
I managed to create feed storage with signatures signed by multiple different keys!  The software didn't complain at all, but nobody could download from me.

This patch prevents that from beginning.