### PR TITLE
Add signature() and verify() functions to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,30 @@ feed will be marked for download for you when the feed is created.
 
 Cancel a previous download request.
 
+#### `feed.signature([index], callback)`
+
+Get a signature proving the correctness of the block at index, or the whole stream.
+
+Callback is called with `(err, signature)`.
+The signature has the following properties:
+``` js
+{
+  index: lastSignedBlock,
+  signature: Buffer
+}
+```
+
+#### `feed.verify(index, signature, callback)`
+
+Verify a signature is correct for the data up to index, which must be the last signed
+block associated with the signature.
+
+Callback is called with `(err, success)` where success is true only if the signature is
+correct.
+
+It is fine if the passed signature is unfamiliar; it is recalculated for verification,
+rather than compared with the local storage.
+
 #### `var number = feed.downloaded([start], [end])`
 
 Returns total number of downloaded blocks within range.

--- a/README.md
+++ b/README.md
@@ -183,9 +183,6 @@ block associated with the signature.
 Callback is called with `(err, success)` where success is true only if the signature is
 correct.
 
-It is fine if the passed signature is unfamiliar; it is recalculated for verification,
-rather than compared with the local storage.
-
 #### `var number = feed.downloaded([start], [end])`
 
 Returns total number of downloaded blocks within range.

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -41,12 +41,26 @@ Storage.prototype.getData = function (index, cb) {
   })
 }
 
+Storage.prototype.nextSignature = function (index, cb) {
+  var self = this
+
+  this._getSignature(index, function (err, signature) {
+    if (err) return cb(err)
+    if (isBlank(signature)) return self.nextSignature(index + 1, cb)
+    cb(null, { index: index, signature: signature })
+  })
+}
+
 Storage.prototype.getSignature = function (index, cb) {
-  this.signatures.read(32 + 64 * index, 64, function (err, signature) {
+  this._getSignature(index, function (err, signature) {
     if (err) return cb(err)
     if (isBlank(signature)) return cb(new Error('No signature found'))
     cb(null, signature)
   })
+}
+
+Storage.prototype._getSignature = function (index, cb) {
+  this.signatures.read(32 + 64 * index, 64, cb)
 }
 
 Storage.prototype.putSignature = function (index, signature, cb) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -52,6 +52,25 @@ tape('flush', function (t) {
   })
 })
 
+tape('verify', function (t) {
+  var feed = create()
+
+  feed.append('test', function (err) {
+    t.error(err, 'no error')
+
+    feed.signature(0, function (err, sig) {
+      t.error(err, 'no error')
+      t.same(sig.index, 0, '0 signed at 0')
+
+      feed.verify(0, sig.signature, function (err, success) {
+        t.error(err, 'no error')
+        t.ok(success)
+        t.end()
+      })
+    })
+  })
+})
+
 tape('pass in secret key', function (t) {
   var keyPair = crypto.keyPair()
   var secretKey = keyPair.secretKey


### PR DESCRIPTION
Allows user to retrieve a small signed proof of a data block and to verify such proofs.

Fixes #125