### PR TITLE
Add support for acknowledgments

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ Options include:
 ``` js
 {
   live: false, // keep replicating after all remote data has been downloaded?
+  ack: false, // set to true to get explicit acknowledgement when a peer has written a block
   download: true, // download data from peers?
   encrypt: true // encrypt the data sent using the hypercore key pair
 }

--- a/index.js
+++ b/index.js
@@ -799,7 +799,7 @@ Feed.prototype._verifyRootsAndWrite = function (index, data, top, proof, nodes, 
 Feed.prototype._announce = function (message, from) {
   for (var i = 0; i < this.peers.length; i++) {
     var peer = this.peers[i]
-    if (peer !== from) peer.have(message)
+    if (peer !== from || peer.remoteAck) peer.have(message)
   }
 }
 

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -45,6 +45,7 @@ function Peer (feed, opts) {
   this.remoteWant = false
   this.live = !!opts.live
   this.sparse = feed.sparse
+  this.ack = !!opts.ack
 
   this.remoteDownloading = true
   this.downloading = typeof opts.download === 'boolean' ? opts.download : !feed.writable
@@ -83,6 +84,7 @@ Peer.prototype.ondata = function (data) {
 
   this.feed._putBuffer(data.index, data.value, data, this, function (err) {
     if (err) return self.destroy(err)
+    if (self.ack) self.have({start: data.index})
     self._clear(data.index, !data.value)
   })
 }
@@ -207,6 +209,9 @@ Peer.prototype.onhave = function (have) {
 
   if (updated) {
     this.feed.emit('remote-update', this)
+    if (this.remoteBitfield.get(have.start)) {
+      this.feed.emit('ack', have.start)
+    }
   }
 
   this._updateEnd()

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -2,6 +2,8 @@ var protocol = require('hypercore-protocol')
 var bitfield = require('sparse-bitfield')
 var set = require('unordered-set')
 var rle = require('bitfield-rle')
+var EventEmitter = require('events').EventEmitter
+var inherits = require('util').inherits
 
 module.exports = replicate
 
@@ -25,6 +27,7 @@ function replicate (feed, opts) {
     peer.remoteId = stream.remoteId
     stream.on('handshake', function () {
       peer.remoteId = stream.remoteId
+      peer.remoteAck = stream.remoteAck
     })
 
     // stream might get destroyed on feed init in case of conf errors
@@ -36,13 +39,16 @@ function replicate (feed, opts) {
   return stream
 }
 
+inherits(Peer, EventEmitter)
 function Peer (feed, opts) {
+  EventEmitter.call(this)
   this.feed = feed
   this.stream = null // set by replicate just after creation
   this.remoteId = null
   this.remoteBitfield = null
   this.remoteLength = 0
   this.remoteWant = false
+  this.remoteAck = false
   this.live = !!opts.live
   this.sparse = feed.sparse
   this.ack = !!opts.ack
@@ -84,7 +90,6 @@ Peer.prototype.ondata = function (data) {
 
   this.feed._putBuffer(data.index, data.value, data, this, function (err) {
     if (err) return self.destroy(err)
-    if (self.ack) self.have({start: data.index})
     self._clear(data.index, !data.value)
   })
 }
@@ -209,9 +214,10 @@ Peer.prototype.onhave = function (have) {
 
   if (updated) {
     this.feed.emit('remote-update', this)
-    if (this.remoteBitfield.get(have.start)) {
-      this.feed.emit('ack', have.start)
-    }
+  }
+
+  if (this.ack && this.remoteBitfield.get(have.start)) {
+    this.emit('ack', have.start)
   }
 
   this._updateEnd()

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "codecs": "^1.2.0",
     "flat-tree": "^1.6.0",
     "from2": "^2.3.0",
-    "hypercore-protocol": "^6.4.1",
+    "hypercore-protocol": "^6.5.0",
     "inherits": "^2.0.3",
     "last-one-wins": "^1.0.4",
     "memory-pager": "^1.0.2",

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -587,6 +587,27 @@ tape('sparse mode, two downloads', function (t) {
   })
 })
 
+tape.only('replicate with ack', function (t) {
+  var feed = create()
+  feed.emilsId = 'feed'
+  feed.on('ready', function () {
+    var clone = create(feed.key)
+    clone.emilsId = 'clone'
+
+    replicate(feed, clone, {live: true, ack: true}).on('handshake', function () {
+      feed.append(['a', 'b', 'c'])
+    })
+
+    clone.on('ack', function (ack) {
+      console.log('clone ack :(')
+    })
+  })
+
+  feed.on('ack', function (ack) {
+    console.log('ackackackackakc', ack)
+  })
+})
+
 function same (t, val) {
   return function (err, data) {
     t.error(err, 'no error')


### PR DESCRIPTION
I want to make a scheme where I can be reasonably certain that n-peers have received a block before I communicate any confidence that a block is safely "committed". This PR goes with the new flag in the protocol handshake and asks peers to acknowledge any blocks they receive. Of course this does not make any guarantees about byzantine peers, so you should only trust the ack if you trust the peer. 

Still needs more tests. 