### PR TITLE
Properly emit decoding errors during reads

### DIFF
--- a/index.js
+++ b/index.js
@@ -1146,7 +1146,12 @@ function toCodec (enc) {
 function wrapCodec (enc, cb) {
   return function (err, buf) {
     if (err) return cb(err)
-    cb(null, enc.decode(buf))
+    try {
+      buf = enc.decode(buf)
+    } catch (err) {
+      return cb(err)
+    }
+    cb(null, buf)
   }
 }
 


### PR DESCRIPTION
I was getting hit with toplevel exceptions that look like this:

```
Error: Groups are not supported
    at exports.skip (/home/pfrazee/hashbase/node_modules/protocol-buffers-encodi
ngs/index.js:29:13)
    at Object.decode (/home/pfrazee/hashbase/node_modules/hyperdrive/lib/message
s.js:98:18)
    at Request._callback (/home/pfrazee/hashbase/node_modules/hypercore/index.js:1149:18)
    at Request.callback (/home/pfrazee/hashbase/node_modules/random-access-storage/index.js:150:8)
    at onread (/home/pfrazee/hashbase/node_modules/random-access-file/index.js:80:31)
```

99% sure this was caused by somebody uploading a non-hyperdrive hypercore to Hashbase.

This PR will make sure that a decoding failure will be emitted as an error rather than thrown as a process exception.