### PR TITLE
Fix: properly remove peers on stream close/end

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -351,20 +351,22 @@ Peer.prototype.end = function () {
 }
 
 Peer.prototype.destroy = function (err) {
-  // make sure the peer is no longer being tracked
-  set.remove(this.feed.peers, this)
-
   // deconstruct any state
-  if (this._index === -1) return
-  for (var i = 0; i < this.inflightRequests.length; i++) {
-    this.feed._reserved.set(this.inflightRequests[i].index, false)
+  if (this._index !== -1) {
+    for (var i = 0; i < this.inflightRequests.length; i++) {
+      this.feed._reserved.set(this.inflightRequests[i].index, false)
+    }
+    this._updateEnd()
+    this._index = -1
+    this.remoteWant = false
+    this.stream.destroy(err)
+    this.feed._updatePeers()
   }
-  this._updateEnd()
-  this._index = -1
-  this.remoteWant = false
-  this.stream.destroy(err)
-  this.feed._updatePeers()
-  this.feed.emit('peer-remove', this)
+
+  // make sure the peer is no longer being tracked
+  if (set.remove(this.feed.peers, this)) {
+    this.feed.emit('peer-remove', this)
+  }
 }
 
 Peer.prototype._downloadWaiting = function (wait) {

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -26,6 +26,8 @@ function replicate (feed, opts) {
     stream.on('handshake', function () {
       peer.remoteId = stream.remoteId
     })
+    stream.on('end', peer.onclose.bind(peer))
+    stream.on('close', peer.onclose.bind(peer))
 
     // stream might get destroyed on feed init in case of conf errors
     if (stream.destroyed) return
@@ -349,8 +351,11 @@ Peer.prototype.end = function () {
 }
 
 Peer.prototype.destroy = function (err) {
-  if (this._index === -1) return
+  // make sure the peer is no longer being tracked
   set.remove(this.feed.peers, this)
+
+  // deconstruct any state
+  if (this._index === -1) return
   for (var i = 0; i < this.inflightRequests.length; i++) {
     this.feed._reserved.set(this.inflightRequests[i].index, false)
   }

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -351,6 +351,11 @@ Peer.prototype.end = function () {
 }
 
 Peer.prototype.destroy = function (err) {
+  // make sure the peer is no longer being tracked
+  if (set.remove(this.feed.peers, this)) {
+    this.feed.emit('peer-remove', this)
+  }
+
   // deconstruct any state
   if (this._index !== -1) {
     for (var i = 0; i < this.inflightRequests.length; i++) {
@@ -361,11 +366,6 @@ Peer.prototype.destroy = function (err) {
     this.remoteWant = false
     this.stream.destroy(err)
     this.feed._updatePeers()
-  }
-
-  // make sure the peer is no longer being tracked
-  if (set.remove(this.feed.peers, this)) {
-    this.feed.emit('peer-remove', this)
   }
 }
 

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -588,6 +588,31 @@ tape('sparse mode, two downloads', function (t) {
   })
 })
 
+tape('peer-add and peer-remove are emitted', function (t) {
+  t.plan(4)
+
+  var feed = create()
+
+  feed.append(['a', 'b', 'c', 'd', 'e'], function () {
+    var clone = create(feed.key)
+
+    feed.on('peer-add', function (peer) {
+      t.pass('peer-add1')
+    })
+    clone.on('peer-add', function (peer) {
+      t.pass('peer-add2')
+    })
+    feed.on('peer-remove', function (peer) {
+      t.pass('peer-remove1')
+    })
+    clone.on('peer-remove', function (peer) {
+      t.pass('peer-remove2')
+    })
+
+    replicate(clone, feed)
+  })
+})
+
 function same (t, val) {
   return function (err, data) {
     t.error(err, 'no error')


### PR DESCRIPTION
Pretty sure this was causing a memory leak. `Peer.onclose()` was never getting called, and so `Peer.destroy()` was only called on certain error conditions. Graceful closes were not getting covered!

Also had to move the removal from the peers list within `destroy()` because the peer may not be totally setup prior to `destroy()` occurring.