### PR TITLE
Make sure the stream is open before using it (close #146)

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -61,6 +61,7 @@ function Peer (feed, opts) {
 }
 
 Peer.prototype.onwant = function () {
+  if (!this.stream) return
   // TODO: reply to the actual want context
   this.remoteWant = true
   var rle = this.feed.bitfield.compress()
@@ -117,6 +118,7 @@ Peer.prototype.onrequest = function (request) {
 
     function onvalue (err, value) {
       if (err) return self.destroy(err)
+      if (!self.stream) return // closed
 
       if (!self.remoteBitfield) self.remoteBitfield = bitfield()
 
@@ -338,7 +340,7 @@ Peer.prototype.ready = function () {
 
 Peer.prototype.end = function () {
   if (!this.downloading && !this.remoteDownloading && !this.live) {
-    if (!this._defaultDownloading) {
+    if (!this._defaultDownloading && this.stream) {
       this.stream.info({downloading: false, uploading: false})
     }
     this._close()
@@ -347,7 +349,9 @@ Peer.prototype.end = function () {
   if (!this._closed) {
     this._closed = true
     this.downloading = false
-    this.stream.info({downloading: false, uploading: true})
+    if (this.stream) {
+      this.stream.info({downloading: false, uploading: true})
+    }
   } else {
     if (!this.live) this._close()
   }
@@ -449,6 +453,7 @@ Peer.prototype._downloadRange = function (range) {
 }
 
 Peer.prototype._request = function (index, bytes, hash) {
+  if (!this.stream) return
   var request = {
     tick: 6,
     bytes: bytes,


### PR DESCRIPTION
Added a bunch of guards against using `.stream` if it's null, which could happen if a call is made after the connection is closed