### PR TITLE
Support onwrite hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,10 @@ Per default hypercore uses [random-access-file](https://github.com/mafintosh/ran
   overwrite: false, // overwrite any old hypercore that might already exist
   valueEncoding: 'json' | 'utf-8' | 'binary', // defaults to binary
   sparse: false, // do not mark the entire feed to be downloaded
-  secretKey: buffer // optionally pass the corresponding secret key yourself
-  storeSecretKey: true // if false, will not save the secret key
-  storageCacheSize: 65536 // the # of entries to keep in the storage system's LRU cache (false or 0 to disable)
+  secretKey: buffer, // optionally pass the corresponding secret key yourself
+  storeSecretKey: true, // if false, will not save the secret key
+  storageCacheSize: 65536, // the # of entries to keep in the storage system's LRU cache (false or 0 to disable)
+  onwrite: (index, data, peer, cb) // optional hook called before data is written after being verified
 }
 ```
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -219,3 +219,23 @@ tape('append, no cache', function (t) {
     })
   })
 })
+
+tape('onwrite', function (t) {
+  var expected = [
+    {index: 0, data: 'hello', peer: null},
+    {index: 1, data: 'world', peer: null}
+  ]
+
+  var feed = create({
+    onwrite: function (index, data, peer, cb) {
+      t.same({index: index, data: data.toString(), peer: peer}, expected.shift())
+      cb()
+    }
+  })
+
+  feed.append(['hello', 'world'], function (err) {
+    t.error(err, 'no error')
+    t.same(expected.length, 0)
+    t.end()
+  })
+})

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -613,6 +613,30 @@ tape('peer-add and peer-remove are emitted', function (t) {
   })
 })
 
+tape('replicate with onwrite', function (t) {
+  var feed = create()
+
+  feed.append(['a', 'b', 'c', 'd', 'e'], function () {
+    var expected = ['a', 'b', 'c', 'd', 'e']
+
+    var clone = create(feed.key, {
+      onwrite: function (index, data, peer, cb) {
+        t.ok(peer, 'has peer')
+        t.same(expected[index], data.toString())
+        expected[index] = null
+        cb()
+      }
+    })
+
+    clone.on('sync', function () {
+      t.same(expected, [null, null, null, null, null])
+      t.end()
+    })
+
+    replicate(feed, clone, {live: true})
+  })
+})
+
 function same (t, val) {
   return function (err, data) {
     t.error(err, 'no error')


### PR DESCRIPTION
``` js
var feed = hypercore('./feed', {
  onwrite: function (index, data, cb) {
    console.log('before write', index, data)
    cb()
  }
})

feed.append('hello world') // triggers the hook

// also triggered if data is written during replication
```

Needs docs and tests. Just testing this out for now