### PR TITLE
Enable access to root hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,12 @@ block associated with the signature.
 Callback is called with `(err, success)` where success is true only if the signature is
 correct.
 
+#### `feed.rootHashes(index, callback)`
+
+Retrieve the root *hashes* for given `index`.
+
+Callback is called with `(err, roots)`; `roots` is an *Array* of root *hashes*.
+
 #### `var number = feed.downloaded([start], [end])`
 
 Returns total number of downloaded blocks within range.

--- a/index.js
+++ b/index.js
@@ -505,7 +505,7 @@ Feed.prototype.signature = function (index, cb) {
 Feed.prototype.verify = function (index, signature, cb) {
   var self = this
 
-  this._getRootsToVerify(index * 2 + 2, {}, [], function (err, roots) {
+  this._withRoots(index, function (err, roots) {
     if (err) return cb(err)
 
     var checksum = crypto.tree(roots)
@@ -516,6 +516,14 @@ Feed.prototype.verify = function (index, signature, cb) {
       cb(null, true)
     }
   })
+}
+
+Feed.prototype.rootHashes = function (index, cb) {
+  this._withRoots(index, cb)
+}
+
+Feed.prototype._withRoots = function (index, cb) {
+  this._getRootsToVerify(index * 2 + 2, {}, [], cb)
 }
 
 Feed.prototype.seek = function (bytes, opts, cb) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -84,6 +84,36 @@ tape('verify', function (t) {
   })
 })
 
+tape('rootHashes', function (t) {
+  t.plan(9)
+
+  var feed = create()
+  var evilfeed = create(feed.key, {secretKey: feed.secretKey})
+
+  feed.append('test', function (err) {
+    t.error(err, 'no error')
+
+    evilfeed.append('t\0st', function (err) {
+      t.error(err, 'no error')
+
+      var result = []
+
+      feed.rootHashes(0, onroots)
+      evilfeed.rootHashes(0, onroots)
+
+      function onroots (err, roots) {
+        t.error(err, 'no error')
+        t.ok(roots instanceof Array)
+        result.push(roots)
+        if (result.length < 2) return
+        t.notEqual(result[0], result[1])
+        t.equal(result[0].length, result[1].length)
+        t.notEqual(Buffer.compare(result[0][0].hash, result[1][0].hash), 0)
+      }
+    })
+  })
+})
+
 tape('pass in secret key', function (t) {
   var keyPair = crypto.keyPair()
   var secretKey = keyPair.secretKey


### PR DESCRIPTION
Root hashes can be accessed via Feed::rootHashes; fixes #142