### PR TITLE
Clarify root hashes documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,15 @@ correct.
 
 Retrieve the root *hashes* for given `index`.
 
-Callback is called with `(err, roots)`; `roots` is an *Array* of root *hashes*.
+Callback is called with `(err, roots)`; `roots` is an *Array* of *Node* objects:
+```
+Node {
+  index: location in the merkle tree of this root
+  size: total bytes in children of this root
+  hash: hash of the children of this root (32-byte buffer)
+}
+```
+
 
 #### `var number = feed.downloaded([start], [end])`
 


### PR DESCRIPTION
Clarifies that the root hashes implementation does not actually provide a straight array of hashes, but rather the objects which wrap them.