### PR TITLE
sync-bitfield event to know when the bitfield has been written

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,10 @@ Emitted when the feed has been appended to (i.e. has a new length / byteLength)
 
 Emitted every time ALL data from `0` to `feed.length` has been downloaded.
 
+#### `feed.on('sync-bitfield')`
+
+Emitted after data has been downloaded and the bitfield has been updated.
+
 #### `feed.on('close')`
 
 Emitted when the feed has been fully closed

--- a/index.js
+++ b/index.js
@@ -1183,6 +1183,7 @@ Feed.prototype._pollWaiting = function () {
 }
 
 Feed.prototype._syncBitfield = function (cb) {
+  var self = this
   var missing = this.bitfield.pages.updates.length
   var next = null
   var error = null
@@ -1212,6 +1213,7 @@ Feed.prototype._syncBitfield = function (cb) {
     if (err) error = err
     if (--missing) return
     cb(error)
+    self.emit('sync-bitfield')
   }
 }
 


### PR DESCRIPTION
For [multifeed-index](https://github.com/noffle/multifeed-index), I need an event to know when I can read records from the log. The `'append'` event happens before the records are written and the `'sync'` event happens before the bitfield is updated after replication. With this additional event, I can tail a hypercore log without subtle timing bugs around replication.