### PR TITLE
Updated process-nextick-args to new major version.

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ var sparseBitfield = require('sparse-bitfield')
 var treeIndex = require('./lib/tree-index')
 var storage = require('./lib/storage')
 var crypto = require('hypercore-crypto')
-var nextTick = require('process-nextick-args')
+var pna = require('process-nextick-args')
 var bufferFrom = require('buffer-from')
 var bufferAlloc = require('buffer-alloc-unsafe')
 var inspect = require('inspect-custom-symbol')
@@ -369,7 +369,7 @@ Feed.prototype.undownload = function (range) {
 
   if (range.callback && range._index > -1) {
     set.remove(this._selections, range)
-    nextTick(range.callback, new Error('Download was cancelled'))
+    pna.nextTick(range.callback, new Error('Download was cancelled'))
     return
   }
 
@@ -383,7 +383,7 @@ Feed.prototype.undownload = function (range) {
 
     if (s.start === start && s.end === end && s.hash === hash && s.linear === linear) {
       set.remove(this._selections, s)
-      nextTick(s.callback, new Error('Download was cancelled'))
+      pna.nextTick(s.callback, new Error('Download was cancelled'))
       return
     }
   }
@@ -474,7 +474,7 @@ Feed.prototype._cancel = function (start, end) {
     var w = this._waiting[i]
     if ((start <= w.start && w.end <= end) || (start <= w.index && w.index < end)) {
       remove(this._waiting, i)
-      if (w.callback) nextTick(w.callback, new Error('Request cancelled'))
+      if (w.callback) pna.nextTick(w.callback, new Error('Request cancelled'))
     }
   }
 }
@@ -504,7 +504,7 @@ Feed.prototype.clear = function (start, end, opts, cb) { // TODO: use same argum
       if (self.bitfield.set(i, false)) modified = true
     }
 
-    if (!modified) return nextTick(cb)
+    if (!modified) return pna.nextTick(cb)
 
     // TODO: write to a tmp/update file that we want to del this incase it crashes will del'ing
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "memory-pager": "^1.0.2",
     "merkle-tree-stream": "^3.0.3",
     "pretty-hash": "^1.0.1",
-    "process-nextick-args": "^1.0.7",
+    "process-nextick-args": "^2.0.0",
     "random-access-file": "^2.0.1",
     "sodium-universal": "^2.0.0",
     "sparse-bitfield": "^3.0.0",


### PR DESCRIPTION
`process-nextick-args` identified a integration problem with `sinon`, `lolex`, ... and changed the API slightly to not create conflicts. This PR updates "pna" to version 2.0.0