### PR TITLE
Specify key type (avoid browser Buffer/ArrayBuffer gotcha)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,18 @@ Per default hypercore uses [random-access-file](https://github.com/mafintosh/ran
 
 You can also set valueEncoding to any [abstract-encoding](https://github.com/mafintosh/abstract-encoding) instance.
 
+__Note:__ The `[key]` and `secretKey` are _Node.js_ buffer instances, not browser-based ArrayBuffer instances. When creating hypercores in browser, if you pass an ArrayBuffer instance, you will get an error similar to `key must be at least 16, was given undefined`. Instead, create a Node.js Buffer instance using [Feross‘s](https://github.com/feross) [buffer](https://github.com/feross/buffer) module (`npm install buffer`). e.g.,
+
+```javascript
+const storage = someRandomAccessStorage
+const myPublicKey = someUint8Array
+
+const Buffer = require('buffer').Buffer
+const hypercorePublicKeyBuffer = Buffer.from(myPublicKeyAsUint8Array.buffer)
+
+const hypercore = hypercore(storage, hypercorePublicKeyBuffer)
+```
+
 #### `feed.append(data, [callback])`
 
 Append a block of data to the feed.


### PR DESCRIPTION
hypercore constructor accepts Node.js Buffer instances, not ArrayBuffer instances. This is a gotcha when using hypercore in the browser. This change explicitly documents this behaviour.