### PR TITLE
batch all writes to storage in append

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -2,6 +2,7 @@ var uint64be = require('uint64be')
 var flat = require('flat-tree')
 var alru = require('array-lru')
 var bufferAlloc = require('buffer-alloc-unsafe')
+var bufferAllocSafe = require('buffer-alloc')
 
 module.exports = Storage
 
@@ -165,6 +166,22 @@ Storage.prototype.getNode = function (index, cb) {
     if (self.cache) self.cache.set(index, val)
     cb(null, val)
   })
+}
+
+Storage.prototype.putNodeBatch = function (index, nodes, cb) {
+  if (!cb) cb = noop
+
+  var buf = bufferAllocSafe(nodes.length * 40)
+
+  for (var i = 0; i < nodes.length; i++) {
+    var offset = i * 40
+    var node = nodes[i]
+    if (!node) continue
+    node.hash.copy(buf, offset)
+    uint64be.encode(node.size, buf, 32 + offset)
+  }
+
+  this.tree.write(32 + 40 * index, buf, cb)
 }
 
 Storage.prototype.putNode = function (index, node, cb) {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "array-lru": "^1.1.0",
     "atomic-batcher": "^1.0.2",
     "bitfield-rle": "^2.2.1",
+    "buffer-alloc": "^1.2.0",
     "buffer-alloc-unsafe": "^1.0.0",
     "buffer-equals": "^1.0.4",
     "buffer-from": "^1.0.0",


### PR DESCRIPTION
Makes all appends to O(log(n)) writes to storage instead of O(n)