### PR TITLE
Add bitfield lock

### DIFF
--- a/index.js
+++ b/index.js
@@ -1363,7 +1363,10 @@ function isBlock (index) {
 
 function defaultStorage (dir) {
   return function (name) {
-    return raf(name, {directory: dir})
+    try {
+      var lock = name === 'bitfield' ? require('fd-lock') : null
+    } catch (err) {}
+    return raf(name, {directory: dir, lock: lock})
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "merkle-tree-stream": "^3.0.3",
     "pretty-hash": "^1.0.1",
     "process-nextick-args": "^1.0.7",
-    "random-access-file": "^2.0.1",
+    "random-access-file": "^2.1.0",
     "sodium-universal": "^2.0.0",
     "sparse-bitfield": "^3.0.0",
     "thunky": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -53,5 +53,8 @@
   "bugs": {
     "url": "https://github.com/mafintosh/hypercore/issues"
   },
-  "homepage": "https://github.com/mafintosh/hypercore"
+  "homepage": "https://github.com/mafintosh/hypercore",
+  "optionalDependencies": {
+    "fd-lock": "^1.0.2"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
     "stream-collector": "^1.0.1",
     "tape": "^4.6.3"
   },
+  "optionalDependencies": {
+    "fd-lock": "^1.0.2"
+  },
   "scripts": {
     "test": "standard && tape test/*.js",
     "bench": "cd bench && ./all.sh"
@@ -53,8 +56,5 @@
   "bugs": {
     "url": "https://github.com/mafintosh/hypercore/issues"
   },
-  "homepage": "https://github.com/mafintosh/hypercore",
-  "optionalDependencies": {
-    "fd-lock": "^1.0.2"
-  }
+  "homepage": "https://github.com/mafintosh/hypercore"
 }


### PR DESCRIPTION
Uses fd-lock (optional dep as it is native with prebuilds) to lock access to the bitfield. Avoids accidental forks by running two hypercores next to each other accessing the same data.