### PR TITLE
Fix link to Dat paper in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ npm install hypercore
 
 [![Build Status](https://travis-ci.org/mafintosh/hypercore.svg?branch=master)](https://travis-ci.org/mafintosh/hypercore)
 
-To learn more about how hypercore works on a technical level read the [Dat paper](https://github.com/datproject/docs/blob/master/papers/dat-paper.pdf).
+To learn more about how hypercore works on a technical level read the [Dat paper](https://github.com/datprotocol/whitepaper/blob/master/dat-paper.pdf).
 
 ## Features
 


### PR DESCRIPTION
This URL is no longer valid: https://github.com/datproject/docs/blob/master/papers/dat-paper.pdf

Found the paper here: https://github.com/datprotocol/whitepaper/blob/master/dat-paper.pdf