### PR TITLE
Run tests on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,7 @@ node_js:
   - '6'
   - '8'
   - '10'
+os:
+  - windows
+  - osx
+  - linux


### PR DESCRIPTION
This PR runs tests on Windows in Travis. It switches to using random-access-file in tests rather than random-access-memory, in order to better replicate a real-world scenario in tests and surface any peculiarities of the filesystem (which it did).

Tests are inconsistently failing on Windows. Help is most welcome figuring out why this is failing.
