### PR TITLE
exclude 'fd-lock' from browser bundling.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
   "optionalDependencies": {
     "fd-lock": "^1.0.2"
   },
+  "browser": {
+    "fd-lock": false
+  },
   "scripts": {
     "test": "standard && nyc tape test/*.js",
     "bench": "cd bench && ./all.sh"


### PR DESCRIPTION
I ran into a problem when bundling hypercore for the browser using choo with bankai. see this issue report for details https://github.com/goto-bus-stop/browser-pack-flat/issues/34. using the `"browser"` block for this purpose seems to be inline with the purpose of the field and it definitely solves my bundling problem. I didn't bump version num because it looks like ya'll like to do that in a separate commit.