### PR TITLE
Add network stats

### DIFF
--- a/bench/helpers/read-throttled.js
+++ b/bench/helpers/read-throttled.js
@@ -25,4 +25,3 @@ module.exports = function (dir, proof) {
 }
 
 function noop () {}
-

--- a/bench/helpers/write.js
+++ b/bench/helpers/write.js
@@ -27,4 +27,3 @@ module.exports = function (dir, blockSize, count, finalize) {
     console.log(Math.floor(1000 * feed.length / (Date.now() - then)) + ' blocks/s')
   }
 }
-

--- a/index.js
+++ b/index.js
@@ -83,8 +83,6 @@ function Feed (createStorage, key, opts) {
   this._reserved = sparseBitfield()
   this._synced = null
 
-  this._stats = null
-
   this._stats = (typeof opts.stats !== 'undefined' && !opts.stats) ? null : {
     downloadedBlocks: 0,
     downloadedBytes: 0,

--- a/index.js
+++ b/index.js
@@ -180,7 +180,7 @@ Feed.prototype.replicate = function (opts) {
     this.download({start: 0, end: -1})
   }
 
-  var opts = opts || {}
+  opts = opts || {}
   opts.stats = !!this._stats
 
   return replicate(this, opts)

--- a/index.js
+++ b/index.js
@@ -85,13 +85,11 @@ function Feed (createStorage, key, opts) {
 
   this._stats = null
 
-  if (typeof opts.stats === 'undefined' || opts.stats) {
-    this._stats = {
-      downloadedBlocks: 0,
-      downloadedBytes: 0,
-      uploadedBlocks: 0,
-      uploadedBytes: 0
-    }
+  this._stats = (typeof opts.stats !== 'undefined' && !opts.stats) ? null : {
+    downloadedBlocks: 0,
+    downloadedBytes: 0,
+    uploadedBlocks: 0,
+    uploadedBytes: 0
   }
 
   this._codec = toCodec(opts.valueEncoding)

--- a/index.js
+++ b/index.js
@@ -83,6 +83,8 @@ function Feed (createStorage, key, opts) {
   this._reserved = sparseBitfield()
   this._synced = null
 
+  this._stats = null
+
   if (typeof opts.stats === 'undefined' || opts.stats) {
     this._stats = {
       downloadedBlocks: 0,

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -86,6 +86,8 @@ function Peer (feed, opts) {
   this._defaultDownloading = this.downloading
   this._iterator = this.remoteBitfield.iterator()
 
+  this._stats = null
+
   if (opts.stats) {
     this._stats = {
       uploadedBytes: 0,

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -127,7 +127,7 @@ Peer.prototype.ondata = function (data) {
   this.feed._putBuffer(data.index, data.value, data, this, function (err) {
     if (err) return self.destroy(err)
     if (data.value) self.remoteBitfield.set(data.index, false)
-    if (self._stats) {
+    if (self._stats && data.value) {
       self._stats.downloadedBlocks += 1
       self._stats.downloadedBytes += data.value.length
     }

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -86,15 +86,11 @@ function Peer (feed, opts) {
   this._defaultDownloading = this.downloading
   this._iterator = this.remoteBitfield.iterator()
 
-  this._stats = null
-
-  if (opts.stats) {
-    this._stats = {
-      uploadedBytes: 0,
-      uploadedBlocks: 0,
-      downloadedBytes: 0,
-      downloadedBlocks: 0
-    }
+  this._stats = !opts.stats ? null : {
+    uploadedBytes: 0,
+    uploadedBlocks: 0,
+    downloadedBytes: 0,
+    downloadedBlocks: 0
   }
 }
 

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -85,6 +85,15 @@ function Peer (feed, opts) {
   this._destroyed = false
   this._defaultDownloading = this.downloading
   this._iterator = this.remoteBitfield.iterator()
+
+  if (opts.stats) {
+    this._stats = {
+      uploadedBytes: 0,
+      uploadedBlocks: 0,
+      downloadedBytes: 0,
+      downloadedBlocks: 0
+    }
+  }
 }
 
 Peer.prototype.onwant = function (want) {
@@ -118,6 +127,10 @@ Peer.prototype.ondata = function (data) {
   this.feed._putBuffer(data.index, data.value, data, this, function (err) {
     if (err) return self.destroy(err)
     if (data.value) self.remoteBitfield.set(data.index, false)
+    if (self._stats) {
+      self._stats.downloadedBlocks += 1
+      self._stats.downloadedBytes += data.value.length
+    }
     self._clear(data.index, !data.value)
   })
 }
@@ -156,6 +169,12 @@ Peer.prototype.onrequest = function (request) {
       if (err) return self.destroy(err)
 
       if (value) {
+        if (self._stats) {
+          self._stats.uploadedBlocks += 1
+          self._stats.uploadedBytes += value.length
+          self.feed._stats.uploadedBlocks += 1
+          self.feed._stats.uploadedBytes += value.length
+        }
         self.feed.emit('upload', request.index, value, self)
       }
 

--- a/test/copy.js
+++ b/test/copy.js
@@ -362,6 +362,7 @@ function runOps (t, ops) {
         t.pass('copied ' + next.block + ' from ' + next.from + ' to ' + next.to)
         loop()
       })
+      return
     }
   }
 }

--- a/test/copy.js
+++ b/test/copy.js
@@ -362,7 +362,6 @@ function runOps (t, ops) {
         t.pass('copied ' + next.block + ' from ' + next.from + ' to ' + next.to)
         loop()
       })
-      return
     }
   }
 }

--- a/test/stats.js
+++ b/test/stats.js
@@ -1,0 +1,77 @@
+var create = require('./helpers/create')
+var replicate = require('./helpers/replicate')
+var tape = require('tape')
+
+tape('accurate stat totals', function (t) {
+  t.plan(4)
+
+  var feed = create()
+  feed.append(['aa', 'bb', 'cc', 'dd', 'ee'], function () {
+    var clone = create(feed.key)
+    replicate(feed, clone).on('end', function () {
+      var feedStats = feed.stats
+      var cloneStats = clone.stats
+
+      t.same(feedStats.totals.uploadedBlocks, 5)
+      t.same(feedStats.totals.uploadedBytes, 10)
+      t.same(cloneStats.totals.downloadedBlocks, 5)
+      t.same(cloneStats.totals.downloadedBytes, 10)
+    })
+  })
+})
+
+tape('accurate per-peer stats', function (t) {
+  t.plan(13)
+
+  var feed = create()
+
+  feed.append(['aa', 'bb', 'cc', 'dd', 'ee'], function () {
+    var clone1 = create(feed.key)
+    var clone2 = create(feed.key)
+
+    replicate(feed, clone1, { live: true })
+    replicate(feed, clone2, { live: true })
+
+    setTimeout(function () {
+      onreplicate(clone1, clone2)
+    }, 50)
+  })
+
+  function onreplicate (clone1, clone2) {
+    var feedStats = feed.stats
+    var clone1Stats = clone1.stats
+    var clone2Stats = clone2.stats
+
+    t.same(feedStats.totals.uploadedBlocks, 10)
+    t.same(feedStats.totals.uploadedBytes, 20)
+    t.same(feedStats.peers.length, 2)
+    t.same(feedStats.peers[0].uploadedBlocks, 5)
+    t.same(feedStats.peers[0].uploadedBytes, 10)
+    t.same(feedStats.peers[1].uploadedBlocks, 5)
+    t.same(feedStats.peers[1].uploadedBytes, 10)
+
+    t.same(clone1Stats.peers.length, 1)
+    t.same(clone1Stats.peers[0].downloadedBytes, 10)
+    t.same(clone1Stats.peers[0].downloadedBlocks, 5)
+
+    t.same(clone2Stats.peers.length, 1)
+    t.same(clone2Stats.peers[0].downloadedBytes, 10)
+    t.same(clone2Stats.peers[0].downloadedBlocks, 5)
+  }
+})
+
+tape('should not collect stats when stats option is false', function (t) {
+  t.plan(2)
+
+  var feed = create({ stats: false })
+  feed.append(['aa', 'bb', 'cc', 'dd', 'ee'], function () {
+    var clone = create(feed.key, { stats: false })
+    replicate(feed, clone).on('end', function () {
+      var feedStats = feed.stats
+      var cloneStats = clone.stats
+
+      t.false(feedStats)
+      t.false(cloneStats)
+    })
+  })
+})


### PR DESCRIPTION
This PR adds the `stats` property, which returns a handful of (currently only network-related) statistics. Stats collection can be disabled by settings `opts.stats` to `false` when creating the hypercore.

Currently, network stats are tracked both a) in total, and b) for each connected peer. Historical stats for disconnected peers are not stored.

The returned stats object has the following form (for a source feed that's uploaded a single 100 byte block to a currently-connected peer):
```js
{
  totals: {
    uploadedBytes: 100,
    uploadedBlocks: 1,
    downloadedBytes: 0,
    downloadedBlocks: 0
  },
  peers: [
    {
      uploadedBytes: 100,
      uploadedBlocks: 1,
      downloadedBytes: 0,
      downloadedBlocks: 0
    },
    ...
  ]
}
```