### PR TITLE
Add update option to head

### DIFF
--- a/index.js
+++ b/index.js
@@ -1059,9 +1059,14 @@ Feed.prototype.head = function (opts, cb) {
   var self = this
   this._ready(function (err) {
     if (err) return cb(err)
+    if (opts && opts.update) self.update(opts, onupdate)
+    else process.nextTick(onupdate)
+  })
+
+  function onupdate () {
     if (self.length === 0) cb(new Error('feed is empty'))
     else self.get(self.length - 1, opts, cb)
-  })
+  }
 }
 
 Feed.prototype.get = function (index, opts, cb) {

--- a/test/head.js
+++ b/test/head.js
@@ -1,0 +1,65 @@
+var create = require('./helpers/create')
+var replicate = require('./helpers/replicate')
+var tape = require('tape')
+
+tape('head without update does not update', t => {
+  var feed1 = create()
+  var feed2 = null
+
+  feed1.append('hello', () => {
+    feed2 = create(feed1.key)
+    replicate(feed1, feed2, { live: true })
+    feed2.head((err, content) => {
+      t.true(err)
+      t.end()
+    })
+  })
+})
+
+tape('head with update waits for an update', t => {
+  var feed1 = create()
+  var feed2 = null
+
+  feed1.append('hello', () => {
+    feed2 = create(feed1.key)
+    feed2.head({ update: true }, (err, content) => {
+      t.error(err, 'no error')
+      t.same(content, Buffer.from('hello'))
+      t.end()
+    })
+    setTimeout(() => {
+      replicate(feed1, feed2)
+    }, 50)
+  })
+})
+
+tape('head with update/ifAvailable will wait only if an update is available', t => {
+  var feed1 = create()
+  var feed2 = null
+
+  feed1.append('hello', () => {
+    feed2 = create(feed1.key)
+    feed2.head({ update: true, ifAvailable: true }, (err, content) => {
+      t.error(err, 'no error')
+      t.same(content, Buffer.from('hello'))
+      t.end()
+    })
+    replicate(feed1, feed2)
+  })
+})
+
+tape('head with update/ifAvailable will not wait forever', t => {
+  var feed1 = create()
+  var feed2 = null
+
+  feed1.append('hello', () => {
+    feed2 = create(feed1.key)
+    feed2.head({ update: true, ifAvailable: true }, (err, content) => {
+      t.true(err)
+      t.end()
+    })
+    setTimeout(() => {
+      replicate(feed1, feed2)
+    }, 50)
+  })
+})


### PR DESCRIPTION
This PR adds the `update` option to the `head` method, which will cause the method to wait for an update before calling `get`.

`head({ update: true, ifAvailable: true }, cb)` will only do an update if one is available.