### PR TITLE
Add upload option to replicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ Options include:
   live: false, // keep replicating after all remote data has been downloaded?
   ack: false, // set to true to get explicit acknowledgement when a peer has written a block
   download: true, // download data from peers?
+  upload: true, // upload data to peers?
   encrypted: true, // encrypt the data sent using the hypercore key pair
   keyPair: { publicKey, secretKey } // use this keypair for Noise authentication
 }

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -64,7 +64,7 @@ function Peer (feed, opts) {
   this.remoteUploading = true
   this.remoteExtensions = feed.extensions.remote()
   this.downloading = typeof opts.download === 'boolean' ? opts.download : feed.downloading
-  this.uploading = feed.uploading
+  this.uploading = typeof opts.upload === 'boolean' ? opts.upload : feed.uploading
 
   this.updated = false
 

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -592,6 +592,25 @@ tape('replicate no download', function (t) {
   })
 })
 
+tape('replicate no upload', function (t) {
+  var feed = create()
+
+  feed.append(['a', 'b', 'c', 'd', 'e'], function () {
+    var clone = create(feed.key)
+
+    clone.get(0, function () {
+      t.fail('Data was received')
+    })
+
+    replicate(feed, clone, { live: true, upload: false }, { live: true })
+
+    setTimeout(function () {
+      t.pass('No data was received')
+      t.end()
+    }, 300)
+  })
+})
+
 tape('sparse mode, two downloads', function (t) {
   var feed = create()
 


### PR DESCRIPTION
The `upload` option to replicate exists in older docs. This PR brings it back. When set to true data from the feed will not be uploaded to peers.