### PR TITLE
fix: don't apply timeout if not available

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -267,8 +267,9 @@ Peer.prototype._onrequesttimeout = function () {
     this.inflightRequests.shift()
     this.feed._reserved.set(first.index, false)
 
-    const ms = this.stream.stream.timeout ? this.stream.stream.timeout.ms : 20000
-    this._requestTimeout = timeout(ms, this._onrequesttimeout, this)
+    if (this.stream.stream.timeout) {
+      this._requestTimeout = timeout(this.stream.stream.timeout.ms, this._onrequesttimeout, this)
+    }
     return
   }
 
@@ -682,9 +683,8 @@ Peer.prototype._request = function (index, bytes, hash) {
     nodes: this.feed.digest(index)
   }
 
-  if (this._requestTimeout === null) {
-    const ms = this.stream.stream.timeout ? this.stream.stream.timeout.ms : 20000
-    this._requestTimeout = timeout(ms, this._onrequesttimeout, this)
+  if (this._requestTimeout === null && this.stream.stream.timeout) {
+    this._requestTimeout = timeout(this.stream.stream.timeout.ms, this._onrequesttimeout, this)
   }
   this.inflightRequests.push(request)
   this.stream.request(request)


### PR DESCRIPTION
I made a mistake in https://github.com/mafintosh/hypercore/pull/239: having no timeout set *should* skip the request timeout timers.