### PR TITLE
Optionally disable NOISE handshake and capability verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ Options include:
   download: true, // download data from peers?
   upload: true, // upload data to peers?
   encrypted: true, // encrypt the data sent using the hypercore key pair
-  noise: true, // set to false to disable the NOISE handshake completely. This implies encrypted = false, and also disables the capability verification
+  noise: true, // set to false to disable the NOISE handshake completely, and also disable the capability verification. works only together with encrypted = false.
   keyPair: { publicKey, secretKey }, // use this keypair for Noise authentication
   onauthenticate (remotePublicKey, done) // hook that can be used to authenticate the remote peer.
                                          // calling done with an error will disallow the peer from connecting to you.

--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ Options include:
   download: true, // download data from peers?
   upload: true, // upload data to peers?
   encrypted: true, // encrypt the data sent using the hypercore key pair
+  noise: true, // set to false to disable the NOISE handshake completely. This implies encrypted = false, and also disables the capability verification
   keyPair: { publicKey, secretKey }, // use this keypair for Noise authentication
   onauthenticate (remotePublicKey, done) // hook that can be used to authenticate the remote peer.
                                          // calling done with an error will disallow the peer from connecting to you.

--- a/index.js
+++ b/index.js
@@ -212,6 +212,7 @@ Feed.prototype.replicate = function (initiator, opts) {
 
   opts = opts || {}
   opts.stats = !!this._stats
+  opts.noise = !(opts.noise === false && opts.encrypted === false)
 
   var stream = replicate(this, initiator, opts)
   this.emit('replicating', stream)

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -30,9 +30,11 @@ function replicate (feed, initiator, opts) {
     if (stream.destroyed) return
     if (stream.opened(feed.key)) return
 
-    if (stream.remoteOpened(feed.key) && !stream.remoteVerified(feed.key)) {
-      stream.close(feed.discoveryKey)
-      return
+    if (opts.noise !== false) {
+      if (stream.remoteOpened(feed.key) && !stream.remoteVerified(feed.key)) {
+        stream.close(feed.discoveryKey)
+        return
+      }
     }
 
     var peer = new Peer(feed, opts)

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -831,11 +831,11 @@ tape('regression: replicate without timeout', function (t) {
   })
 })
 
-tape('replicate with NOISE disabled', function (t) {
+tape.only('replicate with NOISE disabled', function (t) {
   var feed = create()
   feed.append(['a', 'b', 'c'], function () {
     var clone = create(feed.key)
-    const stream = replicate(feed, clone, {live: false, noise: false})
+    const stream = replicate(feed, clone, {live: false, noise: false, encrypted: false})
     clone.get(2, (err, data) => {
       t.error(err, 'no error')
       t.same(data.toString(), 'c')

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -831,6 +831,20 @@ tape('regression: replicate without timeout', function (t) {
   })
 })
 
+tape('replicate with NOISE disabled', function (t) {
+  var feed = create()
+  feed.append(['a', 'b', 'c'], function () {
+    var clone = create(feed.key)
+    const stream = replicate(feed, clone, {live: false, noise: false})
+    clone.get(2, (err, data) => {
+      t.error(err, 'no error')
+      t.same(data.toString(), 'c')
+      t.same(stream.remoteVerified(feed.key), false, 'remote is not verified')
+      t.end()
+    })
+  })
+})
+
 function same (t, val) {
   return function (err, data) {
     t.error(err, 'no error')


### PR DESCRIPTION
This adds an option to disable the NOISE handshake. Note that this also disables the capability system (all capabilities will be null).

Builds upon [simple-hypercore-protocol #2](https://github.com/mafintosh/simple-hypercore-protocol/pull/2) and [hypercore-protocol #50](https://github.com/mafintosh/hypercore-protocol/pull/50).