### PR TITLE
Allow passing custom cache as an option

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,8 @@ function Feed (createStorage, key, opts) {
   this._overwrite = !!opts.overwrite
   this._storeSecretKey = opts.storeSecretKey !== false
   this._merkle = null
-  this._storage = storage(createStorage, opts.storageCacheSize)
+
+  this._storage = storage(createStorage, opts)
   this._batch = batcher(this._onwrite ? workHook : work)
 
   this._seq = 0

--- a/index.js
+++ b/index.js
@@ -99,7 +99,6 @@ function Feed (createStorage, key, opts) {
   this._overwrite = !!opts.overwrite
   this._storeSecretKey = opts.storeSecretKey !== false
   this._merkle = null
-
   this._storage = storage(createStorage, opts)
   this._batch = batcher(this._onwrite ? workHook : work)
 

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -3,9 +3,11 @@ const HypercoreCache = require('hypercore-cache')
 const DEFAULT_TREE_CACHE_SIZE = 65536 * 40
 
 function createCache (opts) {
+  if (opts.cache === false) return {}
+
   const cacheOpts = opts.cache || {}
   if (cacheOpts.tree === undefined || typeof cacheOpts.tree === 'number') {
-    let cacheSize = cacheOpts.tree || opts.storageCacheSize
+    const cacheSize = cacheOpts.tree || opts.storageCacheSize
     cacheOpts.tree = new HypercoreCache({
       maxByteSize: cacheSize !== undefined ? cacheSize : DEFAULT_TREE_CACHE_SIZE,
       estimateSize: () => 40

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,0 +1,26 @@
+var HypercoreCache = require('hypercore-cache')
+
+const DEFAULT_TREE_CACHE_SIZE = 65536 * 40
+
+function createCache (opts) {
+  var cacheOpts = opts.cache || {}
+  if (cacheOpts.tree === undefined || typeof cacheOpts.tree === 'number') {
+    let cacheSize = cacheOpts.tree || opts.storageCacheSize
+    cacheOpts.tree = new HypercoreCache({
+      maxByteSize: cacheSize !== undefined ? cacheSize : DEFAULT_TREE_CACHE_SIZE,
+      estimateSize: () => 40
+    })
+  }
+  if (cacheOpts.data === undefined) return cacheOpts
+  if (typeof cacheOpts.data === 'number') {
+    cacheOpts.data = new HypercoreCache({
+      maxByteSize: cacheOpts.data,
+      estimateSize: buf => buf.length
+    })
+  }
+  return cacheOpts
+}
+
+module.exports = {
+  createCache
+}

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,9 +1,9 @@
-var HypercoreCache = require('hypercore-cache')
+const HypercoreCache = require('hypercore-cache')
 
 const DEFAULT_TREE_CACHE_SIZE = 65536 * 40
 
 function createCache (opts) {
-  var cacheOpts = opts.cache || {}
+  const cacheOpts = opts.cache || {}
   if (cacheOpts.tree === undefined || typeof cacheOpts.tree === 'number') {
     let cacheSize = cacheOpts.tree || opts.storageCacheSize
     cacheOpts.tree = new HypercoreCache({
@@ -21,6 +21,4 @@ function createCache (opts) {
   return cacheOpts
 }
 
-module.exports = {
-  createCache
-}
+module.exports = createCache

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -1,7 +1,6 @@
 var uint64be = require('uint64be')
 var flat = require('flat-tree')
-
-var caching = require('./cache')
+var createCache = require('./cache')
 
 module.exports = Storage
 
@@ -10,7 +9,7 @@ var noarr = []
 function Storage (create, opts) {
   if (!(this instanceof Storage)) return new Storage(create, opts)
 
-  this.cache = caching.createCache(opts)
+  this.cache = createCache(opts)
 
   this.key = null
   this.secretKey = null

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -9,8 +9,10 @@ var noarr = []
 function Storage (create, opts) {
   if (!(this instanceof Storage)) return new Storage(create, opts)
 
-  this.cache = createCache(opts)
+  const cache = createCache(opts)
 
+  this.treeCache = cache.tree || null
+  this.dataCache = cache.data || null
   this.key = null
   this.secretKey = null
   this.tree = null
@@ -33,13 +35,13 @@ Storage.prototype.putData = function (index, data, nodes, cb) {
 
 Storage.prototype.getData = function (index, cb) {
   var self = this
-  var cached = this.cache.data && this.cache.data.get(index)
+  var cached = this.dataCache && this.dataCache.get(index)
   if (cached) return process.nextTick(cb, null, cached)
   this.dataOffset(index, noarr, function (err, offset, size) {
     if (err) return cb(err)
     self.data.read(offset, size, (err, data) => {
       if (err) return cb(err)
-      if (self.cache.data) self.cache.data.set(index, data)
+      if (self.dataCache) self.dataCache.set(index, data)
       return cb(null, data)
     })
   })
@@ -153,8 +155,8 @@ Storage.prototype.getDataBatch = function (start, n, cb) {
 }
 
 Storage.prototype.getNode = function (index, cb) {
-  if (this.cache.tree) {
-    var cached = this.cache.tree.get(index)
+  if (this.treeCache) {
+    var cached = this.treeCache.get(index)
     if (cached) return cb(null, cached)
   }
 
@@ -169,7 +171,7 @@ Storage.prototype.getNode = function (index, cb) {
     if (!size && isBlank(hash)) return cb(new Error('No node found'))
 
     var val = new Node(index, hash, size, null)
-    if (self.cache.tree) self.cache.tree.set(index, val)
+    if (self.treeCache) self.treeCache.set(index, val)
     cb(null, val)
   })
 }

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -153,8 +153,10 @@ Storage.prototype.getDataBatch = function (start, n, cb) {
 }
 
 Storage.prototype.getNode = function (index, cb) {
-  var cached = this.cache.tree.get(index)
-  if (cached) return cb(null, cached)
+  if (this.cache.tree) {
+    var cached = this.cache.tree.get(index)
+    if (cached) return cb(null, cached)
+  }
 
   var self = this
 
@@ -167,7 +169,7 @@ Storage.prototype.getNode = function (index, cb) {
     if (!size && isBlank(hash)) return cb(new Error('No node found'))
 
     var val = new Node(index, hash, size, null)
-    self.cache.tree.set(index, val)
+    if (self.cache.tree) self.cache.tree.set(index, val)
     cb(null, val)
   })
 }

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -1,16 +1,17 @@
 var uint64be = require('uint64be')
 var flat = require('flat-tree')
-var alru = require('array-lru')
+
+var caching = require('./cache')
 
 module.exports = Storage
 
 var noarr = []
 
-function Storage (create, cacheSize) {
-  if (!(this instanceof Storage)) return new Storage(create, cacheSize)
-  cacheSize = typeof cacheSize === 'undefined' ? 65536 : cacheSize
+function Storage (create, opts) {
+  if (!(this instanceof Storage)) return new Storage(create, opts)
 
-  this.cache = cacheSize > 0 ? alru(cacheSize, {indexedValues: true}) : null
+  this.cache = caching.createCache(opts)
+
   this.key = null
   this.secretKey = null
   this.tree = null
@@ -33,9 +34,15 @@ Storage.prototype.putData = function (index, data, nodes, cb) {
 
 Storage.prototype.getData = function (index, cb) {
   var self = this
+  var cached = this.cache.data && this.cache.data.get(index)
+  if (cached) return process.nextTick(cb, null, cached)
   this.dataOffset(index, noarr, function (err, offset, size) {
     if (err) return cb(err)
-    self.data.read(offset, size, cb)
+    self.data.read(offset, size, (err, data) => {
+      if (err) return cb(err)
+      if (self.cache.data) self.cache.data.set(index, data)
+      return cb(null, data)
+    })
   })
 }
 
@@ -57,8 +64,12 @@ Storage.prototype.getSignature = function (index, cb) {
   })
 }
 
+// Caching not enabled for signatures because they are rarely reused.
 Storage.prototype._getSignature = function (index, cb) {
-  this.signatures.read(32 + 64 * index, 64, cb)
+  this.signatures.read(32 + 64 * index, 64, (err, sig) => {
+    if (err) return cb(err)
+    return cb(null, sig)
+  })
 }
 
 Storage.prototype.putSignature = function (index, signature, cb) {
@@ -103,6 +114,7 @@ Storage.prototype.dataOffset = function (index, cachedNodes, cb) {
   }
 }
 
+// Caching not enabled for batch reads because they'd be complicated to batch and they're rarely used.
 Storage.prototype.getDataBatch = function (start, n, cb) {
   var result = new Array(n)
   var sizes = new Array(n)
@@ -145,10 +157,8 @@ Storage.prototype.getDataBatch = function (start, n, cb) {
 }
 
 Storage.prototype.getNode = function (index, cb) {
-  if (this.cache) {
-    var cached = this.cache.get(index)
-    if (cached) return cb(null, cached)
-  }
+  var cached = this.cache.tree.get(index)
+  if (cached) return cb(null, cached)
 
   var self = this
 
@@ -161,7 +171,7 @@ Storage.prototype.getNode = function (index, cb) {
     if (!size && isBlank(hash)) return cb(new Error('No node found'))
 
     var val = new Node(index, hash, size, null)
-    if (self.cache) self.cache.set(index, val)
+    self.cache.tree.set(index, val)
     cb(null, val)
   })
 }

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -66,10 +66,7 @@ Storage.prototype.getSignature = function (index, cb) {
 
 // Caching not enabled for signatures because they are rarely reused.
 Storage.prototype._getSignature = function (index, cb) {
-  this.signatures.read(32 + 64 * index, 64, (err, sig) => {
-    if (err) return cb(err)
-    return cb(null, sig)
-  })
+  this.signatures.read(32 + 64 * index, 64, cb)
 }
 
 Storage.prototype.putSignature = function (index, signature, cb) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "dependencies": {
     "abstract-extension": "^3.0.1",
-    "array-lru": "^1.1.0",
     "atomic-batcher": "^1.0.2",
     "bitfield-rle": "^2.2.1",
     "bulk-write-stream": "^1.1.3",
@@ -13,6 +12,7 @@
     "fast-bitfield": "^1.2.2",
     "flat-tree": "^1.6.0",
     "from2": "^2.3.0",
+    "hypercore-cache": "^1.0.1",
     "hypercore-crypto": "^1.0.0",
     "hypercore-protocol": "^7.9.0",
     "inherits": "^2.0.3",

--- a/test/cache.js
+++ b/test/cache.js
@@ -7,11 +7,11 @@ tape('default options does not use data cache', function (t) {
     t.error(err, 'no error')
     feed.get(0, function (err, block) {
       t.error(err, 'no error')
-      t.same(feed._storage.cache.tree.byteSize, 40)
+      t.same(feed._storage.treeCache.byteSize, 40)
       feed.get(1, function (err, block) {
         t.error(err, 'no error')
-        t.same(feed._storage.cache.tree.byteSize, 80)
-        t.false(feed._storage.cache.data)
+        t.same(feed._storage.treeCache.byteSize, 80)
+        t.false(feed._storage.dataCache)
         t.end()
       })
     })
@@ -27,11 +27,11 @@ tape('numeric data cache opt creates data cache', function (t) {
     t.error(err, 'no error')
     feed.get(0, function (err, block) {
       t.error(err, 'no error')
-      t.true(feed._storage.cache.data)
-      t.same(feed._storage.cache.data.byteSize, firstLength)
+      t.true(feed._storage.dataCache)
+      t.same(feed._storage.dataCache.byteSize, firstLength)
       feed.get(1, function (err, block) {
         t.error(err, 'no error')
-        t.same(feed._storage.cache.data.byteSize, firstLength + secondLength)
+        t.same(feed._storage.dataCache.byteSize, firstLength + secondLength)
         t.end()
       })
     })
@@ -84,8 +84,8 @@ tape('can disable all caching', function (t) {
       t.error(err, 'no error')
       feed.get(1, function (err, block) {
         t.error(err, 'no error')
-        t.false(feed._storage.cache.data)
-        t.false(feed._storage.cache.tree)
+        t.false(feed._storage.dataCache)
+        t.false(feed._storage.treeCache)
         t.end()
       })
     })

--- a/test/cache.js
+++ b/test/cache.js
@@ -20,8 +20,8 @@ tape('default options does not use data cache', function (t) {
 
 tape('numeric data cache opt creates data cache', function (t) {
   var feed = create({ cache: { data: 1024 } })
-  var firstLength = Buffer.from('hello').length
-  var secondLength = Buffer.from('world').length
+  var firstLength = Buffer.byteLength('hello')
+  var secondLength = Buffer.byteLength('world')
 
   feed.append(['hello', 'world'], err => {
     t.error(err, 'no error')

--- a/test/cache.js
+++ b/test/cache.js
@@ -75,3 +75,19 @@ tape('can use a custom cache object', function (t) {
   })
 })
 
+tape('can disable all caching', function (t) {
+  var feed = create({ cache: { tree: false } })
+
+  feed.append(['hello', 'world'], err => {
+    t.error(err, 'no error')
+    feed.get(0, function (err, block) {
+      t.error(err, 'no error')
+      feed.get(1, function (err, block) {
+        t.error(err, 'no error')
+        t.false(feed._storage.cache.data)
+        t.false(feed._storage.cache.tree)
+        t.end()
+      })
+    })
+  })
+})

--- a/test/cache.js
+++ b/test/cache.js
@@ -1,0 +1,40 @@
+var tape = require('tape')
+var create = require('./helpers/create')
+
+tape('default options does not use data cache', function (t) {
+  var feed = create()
+  feed.append(['hello', 'world'], err => {
+    t.error(err, 'no error')
+    feed.get(0, function (err, block) {
+      t.error(err, 'no error')
+      t.same(feed._storage.cache.tree.byteSize, 40)
+      feed.get(1, function (err, block) {
+        t.error(err, 'no error')
+        t.same(feed._storage.cache.tree.byteSize, 80)
+        t.false(feed._storage.cache.data)
+        t.end()
+      })
+    })
+  })
+})
+
+tape('numeric data cache opt creates data cache', function (t) {
+  var feed = create({ cache: { data: 1024 } })
+  var firstLength = Buffer.from('hello').length
+  var secondLength = Buffer.from('world').length
+
+  feed.append(['hello', 'world'], err => {
+    t.error(err, 'no error')
+    feed.get(0, function (err, block) {
+      t.error(err, 'no error')
+      t.true(feed._storage.cache.data)
+      t.same(feed._storage.cache.data.byteSize, firstLength)
+      feed.get(1, function (err, block) {
+        t.error(err, 'no error')
+        t.same(feed._storage.cache.data.byteSize, firstLength + secondLength)
+        t.end()
+      })
+    })
+  })
+})
+

--- a/test/cache.js
+++ b/test/cache.js
@@ -38,3 +38,40 @@ tape('numeric data cache opt creates data cache', function (t) {
   })
 })
 
+tape('can use a custom cache object', function (t) {
+  var treeStorage = []
+  var dataStorage = []
+  var createCache = function (storage) {
+    return {
+      get: function (key) {
+        return storage[key]
+      },
+      set: function (key, value) {
+        storage[key] = value
+      }
+    }
+  }
+
+  var feed = create({
+    cache: {
+      tree: createCache(treeStorage),
+      data: createCache(dataStorage)
+    }
+  })
+  feed.append(['hello', 'world'], err => {
+    t.error(err, 'no error')
+    feed.get(0, function (err, block) {
+      t.error(err, 'no error')
+      t.same(dataStorage.length, 1)
+      t.same(treeStorage.length, 1)
+      feed.get(1, function (err, block) {
+        t.error(err, 'no error')
+        t.same(dataStorage.length, 2)
+        // tree storage should have entries at 0 and 2
+        t.same(treeStorage.length, 3)
+        t.end()
+      })
+    })
+  })
+})
+


### PR DESCRIPTION
This PR adds support for a `cache` option of the form:
```js
{
  tree: (number or cache object),
  data: (number or cache object)
}
```

If the `tree` option is either unspecified or is a number, then a HypercoreCache is created with the default byte size 65536 * 40 (the size of 65536 nodes).

If the `data` option is unspecified, then data caching is disabled. If it is a number, then a HypercoreCache is created of the specified byte size.

By allowing the user to inject a cache into Hypercore, one can reuse a single LRU cache across multiple Hypercore instances, improving resource management.