### PR TITLE
Add top-level ifAvailable option

### DIFF
--- a/index.js
+++ b/index.js
@@ -276,7 +276,7 @@ Feed.prototype.update = function (opts, cb) {
     }
 
     self._waiting.push(w)
-    if (opts.ifAvailable || (self._alwaysIfAvailable && opts.ifAvailable !== false)) self._ifAvailable(w, len)
+    if (typeof opts.ifAvailable === 'boolean' ? opts.ifAvailable : self._alwaysIfAvailable) self._ifAvailable(w, len)
     self._updatePeers()
   })
 }
@@ -1116,7 +1116,7 @@ Feed.prototype.get = function (index, opts, cb) {
     var w = { bytes: 0, hash: false, index: index, options: opts, callback: cb }
     this._waiting.push(w)
 
-    if ((opts && opts.ifAvailable) || (this._alwaysIfAvailable && (!opts || opts.ifAvailable !== false))) this._ifAvailableGet(w)
+    if (opts && typeof opts.ifAvailable === 'boolean' ? opts.ifAvailable : this._alwaysIfAvailable) this._ifAvailableGet(w)
 
     this._updatePeers()
     return

--- a/index.js
+++ b/index.js
@@ -276,7 +276,7 @@ Feed.prototype.update = function (opts, cb) {
     }
 
     self._waiting.push(w)
-    if (opts.ifAvailable || self._alwaysIfAvailable) self._ifAvailable(w, len)
+    if (opts.ifAvailable || (self._alwaysIfAvailable && opts.ifAvailable !== false)) self._ifAvailable(w, len)
     self._updatePeers()
   })
 }
@@ -1116,7 +1116,7 @@ Feed.prototype.get = function (index, opts, cb) {
     var w = { bytes: 0, hash: false, index: index, options: opts, callback: cb }
     this._waiting.push(w)
 
-    if ((opts && opts.ifAvailable) || this._alwaysIfAvailable) this._ifAvailableGet(w)
+    if ((opts && opts.ifAvailable) || (this._alwaysIfAvailable && (!opts || opts.ifAvailable !== false))) this._ifAvailableGet(w)
 
     this._updatePeers()
     return

--- a/index.js
+++ b/index.js
@@ -98,6 +98,7 @@ function Feed (createStorage, key, opts) {
   this._createIfMissing = opts.createIfMissing !== false
   this._overwrite = !!opts.overwrite
   this._storeSecretKey = opts.storeSecretKey !== false
+  this._alwaysIfAvailable = !!opts.ifAvailable
   this._merkle = null
   this._storage = storage(createStorage, opts)
   this._batch = batcher(this._onwrite ? workHook : work)
@@ -275,7 +276,7 @@ Feed.prototype.update = function (opts, cb) {
     }
 
     self._waiting.push(w)
-    if (opts.ifAvailable) self._ifAvailable(w, len)
+    if (opts.ifAvailable || self._alwaysIfAvailable) self._ifAvailable(w, len)
     self._updatePeers()
   })
 }
@@ -1115,7 +1116,7 @@ Feed.prototype.get = function (index, opts, cb) {
     var w = { bytes: 0, hash: false, index: index, options: opts, callback: cb }
     this._waiting.push(w)
 
-    if (opts && opts.ifAvailable) this._ifAvailableGet(w)
+    if ((opts && opts.ifAvailable) || this._alwaysIfAvailable) this._ifAvailableGet(w)
 
     this._updatePeers()
     return

--- a/test/get.js
+++ b/test/get.js
@@ -46,3 +46,19 @@ tape('get with ifAvailable does not wait forever', t => {
     }, 50)
   })
 })
+
+tape('get with top-level ifAvailable option does not wait forever', t => {
+  var feed1 = create()
+  var feed2 = null
+
+  feed1.append('hello', () => {
+    feed2 = create(feed1.key, { ifAvailable: true })
+    feed2.get(0, (err, content) => {
+      t.true(err)
+      t.end()
+    })
+    setTimeout(() => {
+      replicate(feed1, feed2)
+    }, 50)
+  })
+})

--- a/test/update.js
+++ b/test/update.js
@@ -83,6 +83,22 @@ tape('update if available (no one has it)', function (t) {
   })
 })
 
+tape('update if available through top-level option', function (t) {
+  const feed = create()
+
+  feed.append([ 'a', 'b', 'c' ], function () {
+    const clone = create(feed.key, { sparse: true, ifAvailable: true })
+
+    replicate(feed, clone, { live: true })
+
+    clone.update({ minLength: 4 }, function (err) {
+      t.ok(err)
+      t.same(clone.length, 0, 'was not updated')
+      t.end()
+    })
+  })
+})
+
 tape('update with block data', function (t) {
   const feed = create()
 


### PR DESCRIPTION
Passing in `ifAvailable: true` as a top-level hypercore option should force `get` and `update` to always use `ifAvailable` behavior by default, unless overridden by the method option.