### PR TITLE
Add failing ifAvailable seek test

### DIFF
--- a/test/seek.js
+++ b/test/seek.js
@@ -211,7 +211,7 @@ tape('seek ifAvailable multiple peers', function (t) {
   })
 })
 
-tape.only('seek ifAvailable with many inflight requests, multiple peers', function (t) {
+tape.only('seek ifAvailable with many inflight requests', function (t) {
   var feed = create()
 
   var arr = new Array(100).fill('a')

--- a/test/seek.js
+++ b/test/seek.js
@@ -210,3 +210,25 @@ tape('seek ifAvailable multiple peers', function (t) {
     })
   })
 })
+
+tape.only('seek ifAvailable with many inflight requests, multiple peers', function (t) {
+  var feed = create()
+
+  var arr = new Array(100).fill('a')
+
+  feed.append(arr, function () {
+    var clone = create(feed.key, { sparse: true })
+
+    replicate(feed, clone, { live: true })
+
+    // Create 100 inflight requests.
+    for (let i = 0; i < 100; i++) clone.get(i, () => {})
+
+    clone.seek(2, { ifAvailable: true }, function (err, index, offset) {
+      t.error(err, 'no error')
+      t.same(index, 2)
+      t.same(offset, 0)
+      t.end()
+    })
+  })
+})


### PR DESCRIPTION
Here's a failing test for ifAvailable seek. If the number of inflight requests is maxed out, the ifAvailable seek will always error with a "Seek not available from peers" error.