### PR TITLE
Add peer public key and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,10 @@ Send an extension message to a specific peer.
 
 Send a message to every peer you are connected to.
 
+#### `peer.publicKey`
+
+Get the public key buffer for this peer. Useful for identifying a peer in the swarm.
+
 #### `feed.on('ready')`
 
 Emitted when the feed is ready and all properties have been populated.

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -107,6 +107,13 @@ Object.defineProperty(Peer.prototype, 'remoteType', {
   }
 })
 
+Object.defineProperty(Peer.prototype, 'publicKey', {
+  enumerable: true,
+  get: function () {
+    return this.stream.state.remotePublicKey
+  }
+})
+
 Peer.prototype.onwant = function (want) {
   if (!this.uploading) return
   // We only reploy to multipla of 8192 in terms of offsets and lengths for want messages

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -107,7 +107,7 @@ Object.defineProperty(Peer.prototype, 'remoteType', {
   }
 })
 
-Object.defineProperty(Peer.prototype, 'publicKey', {
+Object.defineProperty(Peer.prototype, 'remotePublicKey', {
   enumerable: true,
   get: function () {
     return this.stream.state.remotePublicKey


### PR DESCRIPTION
As per IRC discussion, this exposes a peer's public key without having to muck around with the state.

How's the name? Should it be `remotePublicKey` instead?

Would you like tests that check for its existence?