### PR TITLE
Added destroy method for destroying storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,12 @@ Fully close this feed.
 
 Calls the callback with `(err)` when all storage has been closed.
 
+#### `feed.destroy([callback])`
+
+Destroys all stored data and fully closes this feed.
+
+Calls the callback with `(err)` when all storage has been deleted and closed.
+
 #### `feed.audit([callback])`
 
 Audit all data in the feed. Will check that all current data stored

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -365,12 +365,8 @@ function close (st, cb) {
 }
 
 function destroy (st, cb) {
-  if (st.destroy) {
-    st.destroy(function (err) {
-      if (err) cb(err)
-      else close(st, cb)
-    })
-  } else close(st, cb)
+  if (st.destroy) st.destroy(cb)
+  else cb()
 }
 
 function statAndReadAll (st, offset, pageSize, cb) {

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -229,6 +229,25 @@ Storage.prototype.close = function (cb) {
   }
 }
 
+Storage.prototype.destroy = function (cb) {
+  if (!cb) cb = noop
+  var missing = 6
+  var error = null
+
+  destroy(this.bitfield, done)
+  destroy(this.tree, done)
+  destroy(this.data, done)
+  destroy(this.key, done)
+  destroy(this.secretKey, done)
+  destroy(this.signatures, done)
+
+  function done (err) {
+    if (err) error = err
+    if (--missing) return
+    cb(error)
+  }
+}
+
 Storage.prototype.openKey = function (opts, cb) {
   if (typeof opts === 'function') return this.openKey({}, opts)
   if (!this.key) this.key = this.create('key', opts)
@@ -343,6 +362,15 @@ function isBlank (buf) {
 function close (st, cb) {
   if (st.close) st.close(cb)
   else cb()
+}
+
+function destroy (st, cb) {
+  if (st.destroy) {
+    st.destroy(function (err) {
+      if (err) cb(err)
+      else close(st, cb)
+    })
+  } else close(st, cb)
 }
 
 function statAndReadAll (st, offset, pageSize, cb) {

--- a/test/default-storage.js
+++ b/test/default-storage.js
@@ -20,6 +20,29 @@ tape('default storage works', function (t) {
         feed2.ready(function (err) {
           t.error(err, 'no error')
           t.same(feed2.length, 1)
+          feed2.close(function () {
+            t.end()
+          })
+        })
+      })
+    })
+  })
+})
+
+tape('destroying storage works', function (t) {
+  const dir = path.join(__dirname, 'sandbox')
+  const feed = hypercore(dir, {overwrite: true})
+
+  feed.ready(function () {
+    const key = feed.key
+    t.ok(key, 'generated key')
+    feed.destroy(function () {
+      t.pass('destroyed feed')
+      const feed2 = hypercore(dir)
+
+      feed2.ready(function () {
+        t.notSame(feed2.key, key, 'data got destroyed')
+        feed2.close(function () {
           t.end()
         })
       })


### PR DESCRIPTION
This adds a new `destroy` method to the storage which will destroy all its files if possible, and a `destroy` method on the feed which will invoke that instead of `storage.close`