### PR TITLE
Added peer.on('close')

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,14 @@ Send an extension message to a specific peer.
 
 Send a message to every peer you are connected to.
 
+### `peer.close()`
+
+Close the peer's connection.
+
+### `peer.on('close')
+
+Emitted when the peer's connection has been closed.
+
 #### `peer.publicKey`
 
 Get the public key buffer for this peer. Useful for identifying a peer in the swarm.

--- a/README.md
+++ b/README.md
@@ -487,9 +487,9 @@ Send an extension message to a specific peer.
 
 Send a message to every peer you are connected to.
 
-### `peer.close()`
+### `peer.end()`
 
-Close the peer's connection.
+End the peer's connection, closing it.
 
 ### `peer.on('close')
 

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -573,6 +573,7 @@ Peer.prototype._close = function () {
   if (!this._remoteOpened) {
     this.feed.ifAvailable.continue()
   }
+  this.emit('close')
 }
 
 Peer.prototype.destroy = function (err) {


### PR DESCRIPTION
This makes it easier to deal with peers disconnecting in extension messages and in general when you're tracking a peer object directly.