### PR TITLE
Fix typo (this -> self) in Feed constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ function Feed (createStorage, key, opts) {
 
   if (this.sparse && opts.eagerUpdate) {
     this.update(function loop (err) {
-      if (err) this.emit('update-error', err)
+      if (err) self.emit('update-error', err)
       self.update(loop)
     })
   }


### PR DESCRIPTION
Emit `update-error` from Feed instead of `loop` function on update callback when `eagerUpdate` and `sparse` are enabled.
Fixes #253.