### PR TITLE
Rename .destroy to .destroyData

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ Fully close this feed.
 
 Calls the callback with `(err)` when all storage has been closed.
 
-#### `feed.destroyData([callback])`
+#### `feed.destroyStorage([callback])`
 
 Destroys all stored data and fully closes this feed.
 

--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ Fully close this feed.
 
 Calls the callback with `(err)` when all storage has been closed.
 
-#### `feed.destroy([callback])`
+#### `feed.destroyData([callback])`
 
 Destroys all stored data and fully closes this feed.
 

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ var replicate = require('./lib/replicate')
 var Protocol = require('hypercore-protocol')
 var Message = require('abstract-extension')
 var Nanoresource = require('nanoresource/emitter')
+var util = require('util')
 
 class Extension extends Message {
   broadcast (message) {
@@ -1354,7 +1355,7 @@ Feed.prototype.flush = function (cb) {
   this.append([], cb)
 }
 
-Feed.prototype.destroy = function (cb) {
+Feed.prototype.destroyData = function (cb) {
   const self = this
 
   this.close(function (err) {
@@ -1362,6 +1363,10 @@ Feed.prototype.destroy = function (cb) {
     else self._storage.destroy(cb)
   })
 }
+
+Feed.prototype.destroy = util.deprecate(function (cb) {
+  this.destroyData(cb)
+}, 'feed.destroy() is deprecated. Use feed.destroyData() instead.')
 
 Feed.prototype._close = function (cb) {
   const self = this

--- a/index.js
+++ b/index.js
@@ -22,7 +22,6 @@ var replicate = require('./lib/replicate')
 var Protocol = require('hypercore-protocol')
 var Message = require('abstract-extension')
 var Nanoresource = require('nanoresource/emitter')
-var util = require('util')
 
 class Extension extends Message {
   broadcast (message) {
@@ -1355,7 +1354,7 @@ Feed.prototype.flush = function (cb) {
   this.append([], cb)
 }
 
-Feed.prototype.destroyData = function (cb) {
+Feed.prototype.destroyStorage = function (cb) {
   const self = this
 
   this.close(function (err) {
@@ -1363,10 +1362,6 @@ Feed.prototype.destroyData = function (cb) {
     else self._storage.destroy(cb)
   })
 }
-
-Feed.prototype.destroy = util.deprecate(function (cb) {
-  this.destroyData(cb)
-}, 'feed.destroy() is deprecated. Use feed.destroyData() instead.')
 
 Feed.prototype._close = function (cb) {
   const self = this

--- a/test/default-storage.js
+++ b/test/default-storage.js
@@ -36,7 +36,7 @@ tape('destroying storage works', function (t) {
   feed.ready(function () {
     const key = feed.key
     t.ok(key, 'generated key')
-    feed.destroyData(function () {
+    feed.destroyStorage(function () {
       t.pass('destroyed feed')
       const feed2 = hypercore(dir)
 

--- a/test/default-storage.js
+++ b/test/default-storage.js
@@ -36,7 +36,7 @@ tape('destroying storage works', function (t) {
   feed.ready(function () {
     const key = feed.key
     t.ok(key, 'generated key')
-    feed.destroy(function () {
+    feed.destroyData(function () {
       t.pass('destroyed feed')
       const feed2 = hypercore(dir)
 


### PR DESCRIPTION
This should help make it less confusing since `.destroy()` is used in place of `.close()` in a lot of places.

Deprecated `.destroy` for now since there's some code using it already. 😅